### PR TITLE
[sysvinit] change chkconfig stop order

### DIFF
--- a/files/sensu-gem/sysvinit/sensu-api
+++ b/files/sensu-gem/sysvinit/sensu-api
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework api
 
 ### BEGIN INIT INFO

--- a/files/sensu-gem/sysvinit/sensu-client
+++ b/files/sensu-gem/sysvinit/sensu-client
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework client
 
 ### BEGIN INIT INFO

--- a/files/sensu-gem/sysvinit/sensu-server
+++ b/files/sensu-gem/sysvinit/sensu-server
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework server
 
 ### BEGIN INIT INFO

--- a/files/sensu-gem/sysvinit/sensu-service-init
+++ b/files/sensu-gem/sysvinit/sensu-service-init
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# chkconfig: 345 90 90
+# chkconfig: 345 90 01
 # description: Sensu monitoring framework service
 
 ### BEGIN INIT INFO


### PR DESCRIPTION
This changes the stop priority for systems where chkconfig is in use, ensuring
that Sensu services stop before other services they may depend on or monitor.

Per https://github.com/sensu/sensu-build/pull/94:

> sensu processes should terminate earlier than other processes.
> The case of setting for automatic start in process monitoring,
> it will start the process that has become stopped by shutdown process.

Closes https://github.com/sensu/sensu-build/pull/94
Closes https://github.com/sensu/sensu-build/issues/182