### PR TITLE
use CONFD_DIR in sensu-service binstub options

### DIFF
--- a/files/sensu-gem/bin/sensu-service
+++ b/files/sensu-gem/bin/sensu-service
@@ -70,7 +70,7 @@ svc_exec="/opt/sensu/bin/$sensu_service"
 
 logfile=$LOG_DIR/$sensu_service.log
 pidfile=$PID_DIR/$sensu_service.pid
-options="-c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR -p $pidfile -l $logfile -L $LOG_LEVEL $OPTIONS"
+options="-c $CONFIG_FILE -d $CONFD_DIR -e $EXTENSION_DIR -p $pidfile -l $logfile -L $LOG_LEVEL $OPTIONS"
 
 if [ "x$forking" = "xfork" ]; then
     options="-b $options"
@@ -97,7 +97,7 @@ set_sensu_paths() {
 }
 
 validate() {
-    validate_options="--validate_config -b -c $CONFIG_FILE -d $CONFIG_DIR -e $EXTENSION_DIR $OPTIONS"
+    validate_options="--validate_config -b -c $CONFIG_FILE -d $CONFD_DIR -e $EXTENSION_DIR $OPTIONS"
     $svc_exec $validate_options
 }
 


### PR DESCRIPTION
In da0aebb3bbd936f32170e58b7efc5d6ea7daf173 we reassigned the CONFIG_DIR variable to indicate the path for Sensu's root configuration directory (e.g. /etc/sensu) and added a variable CONFD_DIR to indicate the path for glob-loading Sensu config files. It seems we did not update the `options` and `validate_options` strings accordingly. This change fixes that oversight.