### PR TITLE
[sysvinit] return 0 if pid from file isn't running

### DIFF
--- a/files/sensu-gem/sysvinit/sensu-service-init
+++ b/files/sensu-gem/sysvinit/sensu-service-init
@@ -240,6 +240,17 @@ stop() {
     fi
 
     if [ -n "$pid" ]; then
+  
+        # test if pid is running
+        kill -0 $pid > /dev/null 2>&1
+        retval=$?
+
+        # if the pid is not running service is already stopped
+        if [ $retval -ne 0 ]; then
+          echo_ok
+          return 0
+        fi
+
         kill $pid
 
         retval=$?


### PR DESCRIPTION
Currently the sysv init script will exit if it fails to kill the PID specified by the pidfile, causing restart action to fail when we have a stale pidfile.

This change tests to see if the pid specified by the pidfile is running, exiting normally if it is not, allowing the restart action to succeed despite a stale pidfile.

Closes https://github.com/sensu/sensu/issues/1295