### PR TITLE
update condition guarding rpm signing using GPG_PASSPHRASE env var

### DIFF
--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -42,7 +42,7 @@ end
 package :rpm do
   category "Monitoring"
   vendor vendor
-  signing_passphrase ENV["GPG_PASSPHRASE"] if ENV.key?("GPG_PASSPHRASE")
+  signing_passphrase ENV["GPG_PASSPHRASE"] unless (ENV["GPG_PASSPHRASE"].nil? || ENV["GPG_PASSPHRASE"].empty?)
 end
 
 # TODO: config files are removed during actions such as dpkg --purge


### PR DESCRIPTION
With this change I am able to build rpms without providing GPG credentials