### PR TITLE
update kitchen config to use our own build of centos-5.11 box

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,6 +48,7 @@ platforms:
   - name: centos-5.11
     run_list: yum-epel::default
     driver:
+      box: sensu/centos-5.11
       synced_folders:
         - ['.', '/home/vagrant/sensu', 'type: :rsync']
         <% if gpg_passphrase && gnupg_path %>


### PR DESCRIPTION
box offered by bento project isn't usable on macs. seems to be a problem with
vbox paravirtualization that causes VM to enter an invalid state. We built our
own box with `--paravirtprovider none` which works for our needs right now.