### PR TITLE
Add config yaml and update cookbook to support kitchen-ec2 driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ files/**/cache/
 vendor/cookbooks
 *.lock
 *~
+.envrc

--- a/.kitchen.cloud.yml
+++ b/.kitchen.cloud.yml
@@ -1,0 +1,86 @@
+<%
+build_version = ENV["SENSU_VERSION"]
+build_iteration = ENV["BUILD_NUMBER"]
+gpg_passphrase = ENV["GPG_PASSPHRASE"]
+gnupg_path = ENV["GNUPG_PATH"]
+aws_ssh_key_id = ENV["AWS_SSH_KEY_ID"]
+aws_ssh_key_path = ENV["AWS_SSH_KEY_PATH"]
+
+if gpg_passphrase && gnupg_path
+  # no-op
+elsif gpg_passphrase || gnupg_path
+  raise "Both GPG_PASSPHRASE and GNUPG_PATH must be set for signed RPMs"
+end
+
+unless build_version && build_iteration
+  raise "SENSU_VERSION and BUILD_NUMBER must be set"
+end
+%>
+
+driver:
+  name: ec2
+  instance_type: m3.medium
+  iam_profile_name: sensu-omnibus-artifact-manager
+  <% unless aws_ssh_key_id.nil? %>
+  aws_ssh_key_id: <%= aws_ssh_key_id %>
+  <% end %>
+<% unless aws_ssh_key_path.nil? %>
+transport:
+  ssh_key: <%= aws_ssh_key_path %>
+<% end %>
+
+provisioner:
+  name: chef_zero
+  require_chef_omnibus: 12.13.37
+
+platforms:
+  - name: centos-7
+    run_list: yum-epel::default
+  - name: centos-6
+    run_list: yum-epel::default
+  - name: centos-5.11
+    run_list: yum-epel::default
+  - name: centos-5.11-i386
+    driver:
+      instance_type: m1.medium
+    run_list: yum-epel::default
+  - name: debian-7
+    run_list: apt::default
+  - name: debian-7-i386
+    driver:
+      instance_type: m1.medium
+    run_list: apt::default
+  - name: debian-6
+    run_list: apt::default
+  - name: freebsd-11.0
+    run_list:
+      - omnibus_sensu::freebsd_portsnap
+      - freebsd::pkgng
+  - name: freebsd-10.3
+    run_list:
+      - omnibus_sensu::freebsd_portsnap
+      - freebsd::pkgng
+  - name: freebsd-9.3
+    run_list:
+      - freebsd::portsnap
+      - freebsd::pkgng
+  - name: ubuntu-16.04
+    run_list: apt::default
+  - name: ubuntu-14.04
+    run_list: apt::default
+  - name: ubuntu-12.04
+    run_list: apt::default
+  - name: ubuntu-12.04-i386
+    driver:
+      instance_type: m1.medium
+    run_list: apt::default
+
+suites:
+  - name: default
+    run_list:
+    - omnibus_sensu::default
+    attributes:
+      omnibus_sensu:
+        build_version: "<%= build_version %>"
+        build_iteration: "<%= build_iteration %>"
+        gpg_passphrase: "<%= gpg_passphrase %>"

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :development do
   gem 'berkshelf', '~> 4.2'
 
   # Use Test Kitchen with Vagrant for converging the build environment
-  gem 'test-kitchen',    '~> 1.4'
-  gem 'kitchen-vagrant', '~> 0.18'
+  gem 'test-kitchen',            '~> 1.4'
+  gem 'kitchen-vagrant',         '~> 0.18'
+  gem 'kitchen-ec2',             '~> 1.2'
 end

--- a/site-cookbooks/omnibus_sensu/attributes/default.rb
+++ b/site-cookbooks/omnibus_sensu/attributes/default.rb
@@ -1,1 +1,5 @@
 default["omnibus"]["install_dir"] = "/opt/sensu"
+default["omnibus_sensu"]["project_dir"] = "/opt/sensu-omnibus"
+default["omnibus_sensu"]["aws"]["artifact_bucket_region"] = "us-east-1"
+default["omnibus_sensu"]["aws"]["artifact_bucket_name"] = "sensu-omnibus-artifacts"
+default["omnibus_sensu"]["publish_artifacts"] = true

--- a/site-cookbooks/omnibus_sensu/metadata.rb
+++ b/site-cookbooks/omnibus_sensu/metadata.rb
@@ -7,6 +7,7 @@ long_description 'Installs/Configures omnibus_sensu'
 version '0.1.0'
 
 depends 'omnibus', '4.2.7'
+depends 'git', '~> 5.0'
 
 # If you upload to Supermarket you should set this so your cookbook
 # gets a `View Issues` link

--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -5,6 +5,7 @@
 # Copyright (c) 2016 Sensu, All Rights Reserved.
 
 include_recipe "omnibus::default"
+include_recipe "git"
 
 case node["platform_family"]
 when "rhel"
@@ -16,13 +17,50 @@ gem_package "ffi-yajl" do
   gem_binary "/opt/omnibus-toolchain/bin/gem"
 end
 
+git node["omnibus_sensu"]["project_dir"] do
+  repository 'https://github.com/sensu/sensu-omnibus.git'
+  revision node["omnibus_sensu"]["project_revision"]
+  user node["omnibus"]["build_user"]
+  group node["omnibus"]["build_user_group"]
+  action :sync
+end
+
+shared_env = {
+  "SENSU_VERSION" => node["omnibus_sensu"]["build_version"],
+  "BUILD_NUMBER" => node["omnibus_sensu"]["build_iteration"],
+  "GPG_PASSPHRASE" => node["omnibus_sensu"]["gpg_passphrase"]
+}
+
 omnibus_build "sensu" do
-  project_dir "/home/vagrant/sensu"
+  project_dir node["omnibus_sensu"]["project_dir"]
   log_level :internal
   build_user "root"
-  environment({
-    "SENSU_VERSION" => node["omnibus_sensu"]["build_version"],
-    "BUILD_NUMBER" => node["omnibus_sensu"]["build_iteration"],
-    "GPG_PASSPHRASE" => node["omnibus_sensu"]["gpg_passphrase"]
+  environment shared_env
+end
+
+pkg_suffix_map = {
+  [:ubuntu, :debian]                   => { :default => "deb" },
+  [:redhat, :centos, :fedora, :suse]   => { :default => "rpm" },
+  :solaris                             => { "5.10" => "solaris", "5.11" => "ips" },
+  :aix                                 => { :default => "bff" }
+}
+
+artifact_id = node["omnibus_sensu"]["build_version"] + node["omnibus_sensu"]["build_iteration"]
+
+execute "publish_sensu_#{artifact_id}_artifact" do
+  command(
+    <<-CODE.gsub(/^ {10}/, '')
+          . #{::File.join(build_user_home, 'load-omnibus-toolchain.sh')}
+          bundle exec omnibus publish s3 #{node["omnibus_sensu"]["aws"]["artifact_bucket_name"]} "pkg/sensu*.#{value_for_platform(pkg_suffix_map)}"
+        CODE
+  )
+  cwd node["omnibus_sensu"]["project_dir"]
+  user node["omnibus"]["build_user"]
+  environment shared_env.merge!({
+    'USER' => node["omnibus"]["build_user"],
+    'USERNAME' => node["omnibus"]["build_user"],
+    'LOGNAME' => node["omnibus"]["build_user"],
+    'AWS_S3_BUCKET' => node["omnibus_sensu"]["aws"]["artifact_bucket_name"]
   })
+  only_if lazy { node["omnibus_sensu"]["publish_artifacts"] }
 end


### PR DESCRIPTION
These changes are intended to make our build process work IN DA CLOUD ☁.

In order to use the included `.kitchen.cloud.yml`, I've set the following environment variables :

```
export AWS_REGION=us-west-2
export AWS_DEFAULT_REGION=us-west-2
export AWS_SSH_KEY_ID=cameron-hw
export AWS_SSH_KEY_PATH=~/.ssh/cameron-hw-aws.pem
export KITCHEN_LOCAL_YAML=~/github/sensu-omnibus/.kitchen.cloud.yml
```