### PR TITLE
[chef] Revert "apply git_config resources on all platforms"

### DIFF
--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -36,16 +36,16 @@ if freebsd?
   package "git"
 else
   include_recipe "git"
-end
 
-git_config "user.email" do
-  value "support@sensuapp.com"
-  options "--global"
-end
+  git_config "user.email" do
+    value "support@sensuapp.com"
+    options "--global"
+  end
 
-git_config "user.name" do
-  value "Sensu Omnibus Builder"
-  options "--global"
+  git_config "user.name" do
+    value "Sensu Omnibus Builder"
+    options "--global"
+  end
 end
 
 include_recipe "omnibus::default"


### PR DESCRIPTION
The git_config provider does not work independently of the install methods,
which do not currently support freebsd, so we're moving them back into a
conditional that skips them on freebsd systems.

This reverts commit 0d9d6c61ee54bf249f941e9a108f8d3a2892d16c.