### PR TITLE
use sensu branch of sensu/omnibus fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gem 'rake'
 
 # Install omnibus
-gem 'omnibus', :git => 'https://github.com/sensu/omnibus.git', :branch => 'master'
+gem 'omnibus', :git => 'https://github.com/sensu/omnibus.git', :branch => 'sensu'
 gem 'ffi-yajl', '2.3.0'
 gem 'artifactory', '2.5.1'
 


### PR DESCRIPTION
Update bundle to use `sensu` branch of sensu/omnibus instead of `master`, as `master` has been rolled back to follow upstream.