### PR TITLE
[travis] fail the build when multiple tags detected on same commit

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,17 +4,26 @@ set -e
 
 if [ "x${BUILD_PLATFORM}" == "x" ]; then
     echo "!!! BUILD_PLATFORM not set, exiting."
-    exit
+    exit 2
 fi
 
 OMNIBUS_COMMIT=`git rev-parse HEAD`
 
 if [ `git describe --tags --exact-match $OMNIBUS_COMMIT` ]; then
+    TAGS=`git tag -l --points-at HEAD`
+    TAG_COUNT=`echo $TAGS | tr '[[:space:]]' '\n' | wc -l`
+
+    # Please use unique commits when creating tags to trigger this build
+    if [[ "$TAG_COUNT" -ne "1" ]] ; then
+        echo "Error: Found multiple tags matching $OMNIBUS_COMMIT : $(echo $TAGS)"
+        exit 2
+    fi
+
     export SENSU_VERSION=`git describe --abbrev=0 --tags | awk -F'-' '{print $1}' | sed 's/v//g'`
     export BUILD_NUMBER=`git describe --abbrev=0 --tags | awk -F'-' '{print $2}'`
     echo "============================ Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM} ============================"
     bundle exec rake kitchen:default-$BUILD_PLATFORM
 else
     echo "!!! Commit ${OMNIBUS_COMMIT} is not tagged, exiting."
-    exit
+    exit 2
 fi


### PR DESCRIPTION
When the build is tagged more than once, build.sh currently detects only the
first tag. This makes it likely that the system will build artifacts for a build
number that already exists. By failing the build under these conditions we hope
to avoid wasting cycles on building the wrong thing.