### PR TITLE
[travis] reprioritize job matrix, add windows-2012-r2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,14 +16,15 @@ branches:
 env:
   matrix:
   - BUILD_PLATFORM=debian-8
+  - BUILD_PLATFORM=centos-7
+  - BUILD_PLATFORM=ubuntu-1604
+  - BUILD_PLATFORM=windows-2012-r2
   - BUILD_PLATFORM=debian-7
   - BUILD_PLATFORM=debian-7-i386
-  - BUILD_PLATFORM=ubuntu-1604
   - BUILD_PLATFORM=ubuntu-1404
   - BUILD_PLATFORM=ubuntu-1404-i386
   - BUILD_PLATFORM=ubuntu-1204
   - BUILD_PLATFORM=ubuntu-1204-i386
-  - BUILD_PLATFORM=centos-7
   - BUILD_PLATFORM=centos-6
   - BUILD_PLATFORM=centos-6-i386
   - BUILD_PLATFORM=centos-5


### PR DESCRIPTION
Let's give higher priority to more recent Linux platforms by running them first,
and add Windows 2012r2 to our matrix.

Windows builds take almost 2hrs to complete, so we're counting on the charity of
our friends at Travis CI to have made a behind-the-scenes change for us.