### PR TITLE
Drop test-kitchen support for freebsd-10-i386

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -109,13 +109,6 @@ platforms:
     run_list:
       - omnibus_sensu::freebsd_portsnap
       - freebsd::pkgng
-  - name: freebsd-10-i386
-    driver:
-      instance_type: m1.medium
-      user_data: "user-data/freebsd.sh"
-    run_list:
-      - omnibus_sensu::freebsd_portsnap
-      - freebsd::pkgng
   - name: ubuntu-16.04
     run_list: apt::default
   - name: ubuntu-16.04-i386

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ platform and architecture combinations:
 | CentOS 5           | ✅     | ✅     | 32 and 64bit images built with [sensu-omnibus-packer](https://github.com/sensu/sensu-omnibus-packer) |
 | CentOS 6           | ✅     | ✅     | Using unofficial 32bit image |
 | CentOS 7           | ✅     | ❌     | No official 32bit images |
-| FreeBSD 10         | ✅     | ✅     |                          |
+| FreeBSD 10         | ✅     | ❌     | Official 32bit images are out of date |
 | FreeBSD 11         | ✅     | ❌     | No official 32bit images |
 
 ### Packages Built By Hand


### PR DESCRIPTION
Our FreeBSD 10 i386 build is currently failing. This is due to the `pkg` command segfaulting when we try to install sudo and the latest CA Root certificates. After some research I have discovered that this is due to the latest `pkg` command not supporting FreeBSD 10.1 which is what our build AMI includes.

It seems that FreeBSD stopped publishing i386 cloud images for AWS after FreeBSD 10.1 was released. As a result we will need to build our own AMI (based on a release >= 10.3 and < 11) to support FreeBSD 10 i386 builds.

This PR removes FreeBSD 10 i386 from our build pipeline (for now).