### PR TITLE
[package-scripts] add freebsd to platform_family conditions

### DIFF
--- a/config/templates/package-scripts/postrm.erb
+++ b/config/templates/package-scripts/postrm.erb
@@ -24,7 +24,8 @@ purge_sensu_services()
   rmssys -s sensu-server > /dev/null 2>&1
 <% when "solaris" -%>
   rm -f /lib/svc/manifest/site/sensu-client.xml
-<% when "debian", "rhel" -%>
+<% when "debian", "rhel", "freebsd" -%>
+# this is a noop on <%= platform_family %>
 <% else raise "Service cleanup undefined for platform family \"#{platform_family}\"" -%>
 <% end -%>
 }

--- a/config/templates/package-scripts/prerm.erb
+++ b/config/templates/package-scripts/prerm.erb
@@ -48,6 +48,8 @@ when "aix" -%>
       set -e
     fi
   done
+<% when "freebsd" -%>
+# this is a noop on <%= platform_family %>
 <% else raise "Service management undefined for platform family \"#{platform_family}\"" -%>
 <% end -%>
 }


### PR DESCRIPTION
FreeBSD builds are failing because we forgot to account for that platform in our
erb templates. Oops!