### PR TITLE
[sensu-gem] only touch .keep files for non-linux platforms

### DIFF
--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -53,17 +53,21 @@ build do
   mkdir("/lib/svc/manifest/site") if solaris?
   mkdir("#{etc_dir}/default") unless rhel? || debian? # if directory doesn't exist would be better
 
-  # .keep files to ensure all directories have at least one file
-  touch("#{etc_dir}/sensu/conf.d/.keep")
-  touch("#{etc_dir}/sensu/extensions/.keep")
-  touch("#{etc_dir}/sensu/plugins/.keep")
-  touch("/var/log/sensu/.keep")
-  touch("/var/run/sensu/.keep")
-  touch("/var/cache/sensu/.keep")
+
+  case ohai["platform_family"]
+  when "rhel", "debian"
+  else
+    # Packagers for non-linux platforms tend to need .keep files to ensure
+    # otherwise empty directories are part of the final package.
+    touch("#{etc_dir}/sensu/conf.d/.keep")
+    touch("#{etc_dir}/sensu/extensions/.keep")
+    touch("#{etc_dir}/sensu/plugins/.keep")
+    touch("/var/log/sensu/.keep")
+    touch("/var/run/sensu/.keep")
+    touch("/var/cache/sensu/.keep")
+  end
 
   # sensu-install (in omnibus bin dir)
-
-  # sensu-install
   if windows?
     copy("#{files_dir}/sensu-install.bat", "#{bin_dir}/sensu-install")
   else


### PR DESCRIPTION
We've encountered errors upgrading Sensu deb packages on systems where
sensu-enterprise is installed:

```
dpkg: warning: overriding problem because --force enabled:
dpkg: warning: trying to overwrite '/etc/sensu/conf.d/.keep', which is also in
package sensu-enterprise 2.2.0-1
dpkg: warning: overriding problem because --force enabled:
dpkg: warning: trying to overwrite '/etc/sensu/plugins/.keep', which is also in
package sensu-enterprise 2.2.0-1
dpkg: warning: overriding problem because --force enabled:
dpkg: warning: trying to overwrite '/var/log/sensu/.keep', which is also in
package sensu-enterprise 2.2.0-1
dpkg: warning: unable to delete old directory '/etc/sensu/handlers': Directory
not empty
```

We really only need these .keep files for some subset of packgers which will
omit empty directories from the final package, so this change skips touching
those keep files when we're building on rhel or debian platform_family.