### PR TITLE
[sensu_gem] update sensu-client-windows.xml with known-working copy

### DIFF
--- a/files/sensu-gem/sensu-client-windows.xml
+++ b/files/sensu-gem/sensu-client-windows.xml
@@ -6,8 +6,11 @@
   <name>Sensu Client</name>
   <description>This service runs a Sensu client</description>
   <executable>C:\opt\sensu\embedded\bin\ruby</executable>
-  <arguments>C:\opt\sensu\embedded\bin\sensu-client
-  -l C:\opt\sensu\sensu-client.log
-  -c C:\opt\sensu\config.json
-  -d C:\opt\sensu\conf.d</arguments>
+  <argument>C:\opt\sensu\embedded\bin\sensu-client</argument>
+  <argument>-l</argument>
+  <argument>C:\opt\sensu\sensu-client.log</argument>
+  <argument>-c</argument>
+  <argument>C:\opt\sensu\config.json</argument>
+  <argument>-d</argument>
+  <argument>C:\opt\sensu\conf.d</argument>
 </service>


### PR DESCRIPTION
In interactive testing I've had no luck using `<arguments>` (plural), so this
implementation uses `<argument>` (singular) tags, and adds -c flag for behavior
consistent with Linux installations.

Assumes existence of C:\opt\sensu\conf.d, a directory which isn't currently created by the MSI.