### PR TITLE
Use rubysl-readline on FreeBSD instead of rb-readline

### DIFF
--- a/config/software/rubysl-readline-gem.rb
+++ b/config/software/rubysl-readline-gem.rb
@@ -1,0 +1,13 @@
+name "rubysl-readline-gem"
+default_version "2.0.2"
+
+dependency "ruby"
+dependency "rubygems"
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  gem "install rubysl-readline" \
+    " --version '#{version}'" \
+    " --no-ri --no-rdoc", env: env
+end

--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -4,7 +4,11 @@ default_version "0.26.1"
 dependency "ruby"
 dependency "rubygems"
 dependency "libffi"
-dependency "rb-readline-gem"
+if freebsd?
+  dependency "rubysl-readline-gem"
+else
+  dependency "rb-readline-gem"
+end
 dependency "eventmachine"
 dependency "winsw" if windows?
 


### PR DESCRIPTION
The `rb-readline` gem does not seem to work on FreeBSD. I manually installed the `rubysl-readline` gem as an alternative and it appears to be functioning correctly.