### PR TITLE
[winsw] update to version 2.0.1

### DIFF
--- a/config/software/winsw.rb
+++ b/config/software/winsw.rb
@@ -1,10 +1,10 @@
 name "winsw"
-default_version "2.0.0"
+default_version "2.0.1"
 
 source url: "https://github.com/kohsuke/winsw/releases/download/winsw-v#{version}/WinSW.NET4.exe"
 
-version "2.0.0" do
-  source md5: "3e085789b572149b73e727a48581dd72"
+version "2.0.1" do
+  source md5: "6f9f9554e66cdf3bb26d80512b7afc4f"
 end
 
 relative_path "winsw-v#{version}"


### PR DESCRIPTION
Version 2.0.0 of winsw contains a regression which broke backward compatibility with `<arguments>` tags. This change updates our use of winsw to the 2.0.1 version, which fixes this regression.