### PR TITLE
[travis] refactor build.sh to handle commits with multiple tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,27 +7,29 @@ if [ "x${BUILD_PLATFORM}" == "x" ]; then
     exit 2
 fi
 
-OMNIBUS_COMMIT=`git rev-parse HEAD`
+OMNIBUS_COMMIT=$(git rev-parse HEAD)
 
-if [ `git describe --tags --exact-match $OMNIBUS_COMMIT` ]; then
-    TAGS=`git tag -l --points-at HEAD`
-    TAG_COUNT=`echo $TAGS | tr '[[:space:]]' '\n' | wc -l`
+if [ "$(git describe --tags --exact-match "$OMNIBUS_COMMIT")" ]; then
+    # sort=-v:refname will reverse sort tags, treating them as versions, on git 2.0 and later
+    OMNIBUS_TAG=$(git tag -l --points-at HEAD --sort=-v:refname | awk 'NR==1{print $1}')
+    SENSU_VERSION=$(echo "$OMNIBUS_TAG" | awk -F'-' '{print $1}' | sed 's/v//g')
+    BUILD_NUMBER=$(echo "$OMNIBUS_TAG" | awk -F'-' '{print $2}')
 
-    # Please use unique commits when creating tags to trigger this build
-    if [[ "$TAG_COUNT" -ne "1" ]] ; then
-        echo "Error: Found multiple tags matching $OMNIBUS_COMMIT : $(echo $TAGS)"
-        exit 2
-    fi
+    export SENSU_VERSION BUILD_NUMBER
 
-    export SENSU_VERSION=`git describe --abbrev=0 --tags | awk -F'-' '{print $1}' | sed 's/v//g'`
-    export BUILD_NUMBER=`git describe --abbrev=0 --tags | awk -F'-' '{print $2}'`
-    echo "============================ Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM} ============================"
+    if [[ "x$SENSU_VERSION" != "x" ]] && [[ "x$BUILD_NUMBER" != "x" ]]; then
+       echo "============================ Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM} ============================"
 
-    if [[ "x$TRAVIS_WAIT" == "x" ]] ; then
-        bundle exec rake kitchen:default-$BUILD_PLATFORM
+       if [[ "x$TRAVIS_WAIT" == "x" ]] ; then
+           bundle exec rake kitchen:default-"$BUILD_PLATFORM"
+       else
+           # shellcheck source=.travis/functions.sh
+           source "$TRAVIS_BUILD_DIR/.travis/functions.sh"
+           travis_wait "$TRAVIS_WAIT" bundle exec rake kitchen:default-"$BUILD_PLATFORM"
+       fi
     else
-        source "$TRAVIS_BUILD_DIR/.travis/functions.sh"
-        travis_wait $TRAVIS_WAIT bundle exec rake kitchen:default-$BUILD_PLATFORM
+        echo "!!! Failed to parse tag \"$OMNIBUS_TAG\" into version ($SENSU_VERSION) and build number ($BUILD_NUMBER)"
+        exit 2
     fi
 else
     echo "!!! Commit ${OMNIBUS_COMMIT} is not tagged, exiting."


### PR DESCRIPTION
Relies on --sort behavior present in Git 2.0 and later.

Also updated script syntax to pass [shellcheck](http://www.shellcheck.net/) linter.

Closes #108