### PR TITLE
Only run prerm/postrm scripts on RPM uninstall action

### DIFF
--- a/config/templates/package-scripts/postinst.erb
+++ b/config/templates/package-scripts/postinst.erb
@@ -133,9 +133,32 @@ create_system_services()
   <% end -%>
 }
 
+<% case platform_family
+  when "rhel" -%>
+if [ $1 -eq 1 ]; then
+  create_sensu_user_group
+fi
+chown_sensu_dirs
+<% when "debian" -%>
+case "$1" in
+  configure)
+    create_sensu_user_group
+    chown_sensu_dirs
+    ;;
+
+  abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+<% else -%>
 create_sensu_user_group
 chown_sensu_dirs
 create_system_services
+<% end -%>
 
 exit 0
 EOF

--- a/config/templates/package-scripts/postinst.erb
+++ b/config/templates/package-scripts/postinst.erb
@@ -137,7 +137,5 @@ create_sensu_user_group
 chown_sensu_dirs
 create_system_services
 
-echo "Thank you for installing Sensu!"
-
 exit 0
 EOF

--- a/config/templates/package-scripts/postrm.erb
+++ b/config/templates/package-scripts/postrm.erb
@@ -43,15 +43,30 @@ purge_sensu_files()
 
 # only execute this script on rhel-based distros if an rpm uninstall
 # is taking place
-<% if platform_family == "rhel" -%>
+<% case platform_family
+  when "rhel" -%>
 if [ $1 -eq 0 ]; then
-<% end -%>
+  purge_sensu_services
+  purge_sensu_files
+fi
+<% when "debian" -%>
+case "$1" in
+  purge)
+    purge_sensu_services
+    purge_sensu_files
+    ;;
 
+  remove|upgrade|abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+  *)
+    echo "postinst called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+<% else -%>
 purge_sensu_services
 purge_sensu_files
-
-<% if platform_family == "rhel" -%>
-fi
 <% end -%>
 
 exit 0

--- a/config/templates/package-scripts/postrm.erb
+++ b/config/templates/package-scripts/postrm.erb
@@ -41,10 +41,10 @@ purge_sensu_files()
   fi
 }
 
-# only execute this script on rhel-based distros if an rpm uninstall
-# is taking place
 <% case platform_family
   when "rhel" -%>
+# only execute this script on rhel-based distros if an rpm uninstall
+# is taking place
 if [ $1 -eq 0 ]; then
   purge_sensu_services
   purge_sensu_files

--- a/config/templates/package-scripts/postrm.erb
+++ b/config/templates/package-scripts/postrm.erb
@@ -41,9 +41,17 @@ purge_sensu_files()
   fi
 }
 
+# only execute this script on rhel-based distros if an rpm uninstall
+# is taking place
+<% if platform_family == "rhel" -%>
+if [ $1 -eq 0 ]; then
+<% end -%>
+
 purge_sensu_services
 purge_sensu_files
 
-echo "Sensu has been uninstalled!"
+<% if platform_family == "rhel" -%>
+fi
+<% end -%>
 
 exit 0

--- a/config/templates/package-scripts/preinst.erb
+++ b/config/templates/package-scripts/preinst.erb
@@ -3,5 +3,3 @@
 # Perform necessary sensu setup steps
 # before package is installed.
 #
-
-echo "You're about to install sensu!"

--- a/config/templates/package-scripts/prerm.erb
+++ b/config/templates/package-scripts/prerm.erb
@@ -54,10 +54,20 @@ when "aix" -%>
 <% end -%>
 }
 
+# only execute this script on rhel-based distros if an rpm uninstall
+# is taking place
+<% if platform_family == "rhel" -%>
+if [ $1 -eq 0 ]; then
+<% end -%>
+
 stop_sensu_services
 
 # wait for services to stop
 sleep 6
+
+<% if platform_family == "rhel" -%>
+fi
+<% end -%>
 
 exit 0
 EOF

--- a/config/templates/package-scripts/prerm.erb
+++ b/config/templates/package-scripts/prerm.erb
@@ -56,18 +56,31 @@ when "aix" -%>
 
 # only execute this script on rhel-based distros if an rpm uninstall
 # is taking place
-<% if platform_family == "rhel" -%>
+<% case platform_family
+  when "rhel" -%>
 if [ $1 -eq 0 ]; then
-<% end -%>
+  stop_sensu_services
+fi
+<% when "debian" -%>
+case "$1" in
+  remove|purge)
+    stop_sensu_services
+    ;;
 
+  upgrade|deconfigure)
+    ;;
+
+  *)
+    echo "prerm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+<% else -%>
 stop_sensu_services
+<% end -%>
 
 # wait for services to stop
 sleep 6
-
-<% if platform_family == "rhel" -%>
-fi
-<% end -%>
 
 exit 0
 EOF

--- a/config/templates/package-scripts/prerm.erb
+++ b/config/templates/package-scripts/prerm.erb
@@ -54,10 +54,10 @@ when "aix" -%>
 <% end -%>
 }
 
-# only execute this script on rhel-based distros if an rpm uninstall
-# is taking place
 <% case platform_family
   when "rhel" -%>
+# only execute this script on rhel-based distros if an rpm uninstall
+# is taking place
 if [ $1 -eq 0 ]; then
   stop_sensu_services
 fi


### PR DESCRIPTION
Due to the nature of RPM scriptlet ordering, anyone upgrading from one omnibus-built package to another will result in `/opt/sensu` vanishing. These changes should prevent the scripts from running on anything but an RPM uninstall action.

See https://fedoraproject.org/wiki/Packaging:Scriptlets#Scriptlet_Ordering for more information.