### PR TITLE
Ensure pid dir exists in sysvinit script

### DIFF
--- a/config/templates/sensu-gem/sysvinit/sensu-service.erb
+++ b/config/templates/sensu-gem/sysvinit/sensu-service.erb
@@ -337,6 +337,16 @@ restart() {
     fi
 }
 
+ensure_dir() {
+    if [ ! -d $1 ]; then
+        mkdir -p $1
+        chown -R $2 $1
+        chmod 755 $1
+    fi
+}
+
+ensure_dir $PID_DIR $USER
+
 case "$1" in
     start)
         start


### PR DESCRIPTION
The service wrapper that the sysvinit script calls is run as the `sensu` user which does not have the correct permissions to create the pid directory (`/var/run/sensu`). This PR adds functionality to the sysvinit script to ensure the pid dir exists as root.

Fixes https://github.com/sensu/sensu/issues/1543