### PR TITLE
Another attempt at updating build.sh to handle commits with multiple tags

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,27 +7,28 @@ if [ "x${BUILD_PLATFORM}" == "x" ]; then
     exit 2
 fi
 
-OMNIBUS_COMMIT=`git rev-parse HEAD`
+OMNIBUS_COMMIT=$(git rev-parse HEAD)
 
-if [ `git describe --tags --exact-match $OMNIBUS_COMMIT` ]; then
-    TAGS=`git tag -l --points-at HEAD`
-    TAG_COUNT=`echo $TAGS | tr '[[:space:]]' '\n' | wc -l`
+if [ "$(git describe --tags --exact-match "$OMNIBUS_COMMIT")" ]; then
+    TAGS=$(git tag -l --points-at HEAD)
+    TAG_COUNT=$(echo "$TAGS" | tr '[[:space:]]' '\n' | wc -l)
 
     # Please use unique commits when creating tags to trigger this build
     if [[ "$TAG_COUNT" -ne "1" ]] ; then
-        echo "Error: Found multiple tags matching $OMNIBUS_COMMIT : $(echo $TAGS)"
+        echo "Error: Found multiple tags matching $OMNIBUS_COMMIT : $TAGS"
         exit 2
     fi
 
-    export SENSU_VERSION=`git describe --abbrev=0 --tags | awk -F'-' '{print $1}' | sed 's/v//g'`
-    export BUILD_NUMBER=`git describe --abbrev=0 --tags | awk -F'-' '{print $2}'`
+    SENSU_VERSION=$(git describe --abbrev=0 --tags | awk -F'-' '{print $1}' | sed 's/v//g')
+    BUILD_NUMBER=$(git describe --abbrev=0 --tags | awk -F'-' '{print $2}')
+    export SENSU_VERSION BUILD_NUMBER
     echo "============================ Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM} ============================"
 
     if [[ "x$TRAVIS_WAIT" == "x" ]] ; then
-        bundle exec rake kitchen:default-$BUILD_PLATFORM
+        bundle exec rake kitchen:default-"$BUILD_PLATFORM"
     else
         source "$TRAVIS_BUILD_DIR/.travis/functions.sh"
-        travis_wait $TRAVIS_WAIT bundle exec rake kitchen:default-$BUILD_PLATFORM
+        travis_wait "$TRAVIS_WAIT" bundle exec rake kitchen:default-"$BUILD_PLATFORM"
     fi
 else
     echo "!!! Commit ${OMNIBUS_COMMIT} is not tagged, exiting."

--- a/build.sh
+++ b/build.sh
@@ -11,18 +11,17 @@ OMNIBUS_COMMIT=$(git rev-parse HEAD)
 
 if [ "$(git describe --tags --exact-match "$OMNIBUS_COMMIT")" ]; then
     TAGS=$(git tag -l --points-at HEAD)
-    TAG_COUNT=$(echo "$TAGS" | tr '[[:space:]]' '\n' | wc -l)
+    TAG=$(echo "$TAGS" | sort -r | head -1)
 
-    # Please use unique commits when creating tags to trigger this build
-    if [[ "$TAG_COUNT" -ne "1" ]] ; then
-        echo "Error: Found multiple tags matching $OMNIBUS_COMMIT : $TAGS"
-        exit 2
-    fi
+    echo "======================== Found tags $TAGS on commit $OMNIBUS_COMMIT"
+    echo "======================== Selected $TAG as latest tag"
 
-    SENSU_VERSION=$(git describe --abbrev=0 --tags | awk -F'-' '{print $1}' | sed 's/v//g')
-    BUILD_NUMBER=$(git describe --abbrev=0 --tags | awk -F'-' '{print $2}')
+    SENSU_VERSION=$(echo "$TAG" | awk -F'-' '{print $1}' | sed 's/v//g')
+    BUILD_NUMBER=$(echo "$TAG" | awk -F'-' '{print $2}')
+
     export SENSU_VERSION BUILD_NUMBER
-    echo "============================ Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM} ============================"
+
+    echo "======================== Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM}"
 
     if [[ "x$TRAVIS_WAIT" == "x" ]] ; then
         bundle exec rake kitchen:default-"$BUILD_PLATFORM"


### PR DESCRIPTION
We previously tried to make our build script support multiple tags in #113, which had to be revered due to Travis providing git 1.8, too old for the approach used there.

This approach reverse sorts the tags found by git, on the assumption that the newest tag by date will also be the tag we want to build.

Closes #108 