### PR TITLE
Add config script for AIX

### DIFF
--- a/config/templates/package-scripts/config.erb
+++ b/config/templates/package-scripts/config.erb
@@ -1,0 +1,32 @@
+#!/bin/sh
+#
+# Perform necessary Sensu post install steps
+# after package is installed.
+#
+
+<% if platform_family == "freebsd" -%>
+ETC_DIR=/usr/local/etc
+<% else -%>
+ETC_DIR=/etc
+<% end -%>
+
+INSTALLER_DIR=/opt/sensu
+CONFIG_DIR=$ETC_DIR/sensu
+LOG_DIR=/var/log/sensu
+PID_DIR=/var/run/sensu
+TMP_DIR=/var/cache/sensu
+
+chown_sensu_dirs()
+{
+  chown -Rh 0:0 $INSTALLER_DIR
+  chown -R sensu:sensu $CONFIG_DIR
+  chown -R sensu:sensu $LOG_DIR
+  chown -R sensu:sensu $PID_DIR
+  chown -R sensu:sensu $TMP_DIR
+}
+
+<% if platform_family == "aix" -%>
+chown_sensu_dirs
+<% end -%>
+
+echo "Sensu has been configured!"

--- a/config/templates/package-scripts/postinst.erb
+++ b/config/templates/package-scripts/postinst.erb
@@ -126,9 +126,10 @@ chown_sensu_dirs()
 
 create_system_services()
 {
-  set -e
   <% if platform_family == "aix" -%>
+  set +e
   rmssys -s sensu-client 2>&1 > /dev/null
+  set -e
   mkssys -s sensu-client -p "/opt/sensu/bin/sensu-service" -a "start client" -u sensu -S -n 15 -f 9 > /dev/null
   <% end -%>
 }

--- a/config/templates/package-scripts/prerm.erb
+++ b/config/templates/package-scripts/prerm.erb
@@ -33,6 +33,7 @@ stop_sensu_services()
   set -e
 <% case platform_family
 when "aix" -%>
+  set +e
   stopsrc -s sensu-client > /dev/null 2>&1
 <% when "solaris" -%>
   svcadm disable sensu-client > /dev/null 2>&1


### PR DESCRIPTION
AIX seems to run the `postinst` script prior to finishing the extraction / ownership correction of package files. The `config` script is run afterward so I've copied the `postinst` logic into the new `config` script.

I've also added a few changes to protect against commands, which should be allowed to fail, that may cause the scripts to fail.