### PR TITLE
[package-scripts/postinst] ensure create_system_services() is not empty

### DIFF
--- a/config/templates/package-scripts/postinst.erb
+++ b/config/templates/package-scripts/postinst.erb
@@ -131,6 +131,9 @@ create_system_services()
   rmssys -s sensu-client 2>&1 > /dev/null
   set -e
   mkssys -s sensu-client -p "/opt/sensu/bin/sensu-service" -a "start client" -u sensu -S -n 15 -f 9 > /dev/null
+  <% else -%>
+  # this function is a noop on <%= platform_family %>
+  return
   <% end -%>
 }
 


### PR DESCRIPTION
As of 0.27.1-1 I am seeing errors on fresh install and upgrade, i.e. the following on Ubuntu:
```
/var/lib/dpkg/info/sensu.postinst: 104: /var/lib/dpkg/info/sensu.postinst: Syntax error: "}" unexpected
```

and on Centos:

```
/var/tmp/rpm-tmp.nA2uvr: line 104: syntax error near unexpected token `}'
warning: %post(sensu-1:0.27.1-1.el7.x86_64) scriptlet failed, exit status 2
Non-fatal POSTIN scriptlet failure in rpm package 1:sensu-0.27.1-1.el7.x86_64
  Verifying  : 1:sensu-0.27.1-1.el7.x86_64                                                                                                                                   1/1
```

This change should ensure that the `create_system_services` function is not empty and also a no-op on platforms other than AIX. 