### PR TITLE
[software/eventmachine] update to 1.2.2

### DIFF
--- a/config/software/eventmachine.rb
+++ b/config/software/eventmachine.rb
@@ -6,9 +6,9 @@ dependency "ruby-windows-devkit" if windows?
 
 source git: "https://github.com/eventmachine/eventmachine.git"
 
-default_version "v1.2.1"
+default_version "v1.2.2"
 
-version "v1.2.1" do
+version "v1.2.2" do
   source git: "https://github.com/eventmachine/eventmachine.git"
 end
 
@@ -38,5 +38,5 @@ build do
 
   command "rake gem", env: env
 
-  command "gem install --no-document pkg/eventmachine-1.2.1.gem", env: env
+  command "gem install --no-document pkg/eventmachine-1.2.2.gem", env: env
 end


### PR DESCRIPTION
In https://github.com/sensu/sensu/pull/1562 Sensu's direct dependencies updated EM from 1.2.1 to 1.2.2 but the definition here was not updated. As a result, we published packages which contain EM 1.2.1 from this definition, and EM 1.2.2 without proper OpenSSL support on some platforms (see #124).

This update to 1.2.2 should remove the duplication in the package, and ensure the loaded version of EM has working SSL.

Closes #124 