### PR TITLE
Revert to sensu-build wix upgrade logic

### DIFF
--- a/resources/sensu/msi/source.wxs.erb
+++ b/resources/sensu/msi/source.wxs.erb
@@ -28,8 +28,11 @@
       <![CDATA[Installed OR VersionNT >= 601]]>
     </Condition -->
 
-    <!-- We always do Major upgrades -->
-    <MajorUpgrade DowngradeErrorMessage="!(loc.DowngradeErrorMessage)" />
+    <!-- Major upgrade -->
+    <Upgrade Id="$(var.UpgradeCode)">
+      <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VersionNumber)" IncludeMinimum="no" Property="NEWERVERSIONDETECTED" />
+      <UpgradeVersion Minimum="0.0.0.0" IncludeMinimum="yes" Maximum="$(var.VersionNumber)" IncludeMaximum="no" Property="OLDERVERSIONBEINGUPGRADED" />
+    </Upgrade>
 
     <!--
       If fastmsi is set, custom actions will be invoked during install to unzip


### PR DESCRIPTION
This is an attempt to resolve an issue where multiple copies of Sensu can be simultaneously installed on Windows.