### PR TITLE
[software/eventmachine] add --with-ssl* compile options for windows

### DIFF
--- a/config/software/eventmachine.rb
+++ b/config/software/eventmachine.rb
@@ -28,15 +28,28 @@ build do
   command "gem install --no-document rake-compiler", env: env
   command "rake clean", env: env
 
+  windows_install_prefix = "C:\\opt\\sensu\\embedded"
+
   # disable C++ extensions so we don't need to compile them on platforms
   # we're only using pure_ruby with
   if aix? || solaris?
     patch source: "disable-extensions.patch", plevel: 1, env: patch_env
+  elsif windows?
+    command "rake compile -- --with-ssl-dir=#{windows_install_prefix}\\bin", env: env
   else
     command "rake compile", env: env
   end
 
   command "rake gem", env: env
 
-  command "gem install --no-document pkg/eventmachine-1.2.2.gem", env: env
+  compile_options = ''
+
+  if windows?
+    compile_options << " --with-ssl-dir=#{windows_install_prefix}\\bin"
+    compile_options << " --with-ssl-lib=#{windows_install_prefix}\\lib"
+    compile_options << " --with-ssl-include=#{windows_install_prefix}\\include"
+    compile_options << " --with-opt-include=#{windows_install_prefix}\\include"
+  end
+
+  command "gem install --no-document pkg/eventmachine-1.2.2.gem -- #{compile_options}", env: env
 end


### PR DESCRIPTION
These compile options are present in https://github.com/sensu/sensu-build/blob/master/recipes/sensu.rake but didn't make it into the omnibus software config.