### PR TITLE
[resources/msi] define RemoveExistingProducts in source.wxs.erb

### DIFF
--- a/resources/sensu/msi/source.wxs.erb
+++ b/resources/sensu/msi/source.wxs.erb
@@ -62,11 +62,16 @@
     <InstallExecuteSequence>
       <Custom Action="FastUnzip" After="InstallFiles">NOT Installed</Custom>
       <Custom Action="Cleanup" After="RemoveFiles">REMOVE~="ALL"</Custom>
+      <RemoveExistingProducts After="InstallValidate" />
     </InstallExecuteSequence>
 
     <UI>
       <ProgressText Action="FastUnzip">!(loc.FileExtractionProgress)</ProgressText>
     </UI>
+    <% else %>
+    <InstallExecuteSequence>
+      <RemoveExistingProducts After="InstallValidate" />
+    </InstallExecuteSequence>
     <% end %>
 
     <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
After merging #128 I encountered the following during MSI build:

```
        C:\Users\Administrator\AppData\Local\Temp\sensu20170221-2928-4typwk\source.wxs(34) : error LGHT0094 : Unresolved reference to symbol 'WixAction:InstallExecuteSequence/RemoveExistingProducts' in section 'Product:*'.
```

The changes in this PR seem to clear up this error, and the resulting package installs successfully, with a singular version of Sensu present in "Programs and Features"

