### PR TITLE
[test-kitchen] configure driver to delete ebs volumes on termination

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -43,6 +43,10 @@ driver:
   <% if ENV['TRAVIS'] == 'true' %>
     "travis-job-number": "<%= ENV['TRAVIS_JOB_NUMBER'].nil? ? 'unknown' : ENV['TRAVIS_JOB_NUMBER'] %>"
   <% end %>
+  block_device_mappings:
+    - device_name: /dev/sda1
+      ebs:
+        delete_on_termination: true
 <% unless aws_ssh_key_path.nil? %>
 transport:
   ssh_key: <%= aws_ssh_key_path %>


### PR DESCRIPTION
This change should ensure that EBS volumes are deleted on termination. From examining the block device mapping of running Windows and Linux build instances, I believe this /dev/sda1 device name is suitable for both platforms.