### PR TITLE
Fix RPM signing

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -2,7 +2,7 @@ DEPENDENCIES
   apt (~> 2.8)
   omnibus
     git: https://github.com/sensu/omnibus-cookbook.git
-    revision: 6f4288579104b0e07db9d0f8d8297d29b1695ad6
+    revision: ea67d08c610d3626769e393ca143d2e9bfa4ca11
     ref: sensu
   omnibus_sensu
     path: site-cookbooks/omnibus_sensu

--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -47,10 +47,10 @@ package :rpm do
   category "Monitoring"
   vendor vendor
   if Gem::Version.new(ohai["platform_version"]) >= Gem::Version.new(6)
-    if (ENV["GPG_PASSPHRASE"].nil? || ENV["GPG_PASSPHRASE"].empty?)
-      raise "GPG Passphrase not provided"
+    if ::File.exist?(::File.expand_path('~/.gpg_passphrase'))
+      signing_passphrase ::File.read(::File.expand_path('~/.gpg_passphrase'))
     else
-      signing_passphrase ENV["GPG_PASSPHRASE"]
+      raise "GPG Passphrase not provided"
     end
   end
 end

--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -43,17 +43,23 @@ package :deb do
   vendor vendor
 end
 
+gpg_passphrase = begin
+                   ::File.read('/home/omnibus/.gpg_passphrase')
+                 rescue => e
+                   puts "Failed to load gpg_passphrase: #{e}"
+                   nil
+                 end
+
+platform_version = ohai["platform_version"]
+
 package :rpm do
   category "Monitoring"
   vendor vendor
-  if Gem::Version.new(ohai["platform_version"]) >= Gem::Version.new(6)
-    if ::File.exist?(::File.expand_path('~/.gpg_passphrase'))
-      signing_passphrase ::File.read(::File.expand_path('~/.gpg_passphrase'))
-    else
-      raise "GPG Passphrase not provided"
-    end
+  if Gem::Version.new(platform_version) >= Gem::Version.new(6)
+    signing_passphrase gpg_passphrase
   end
 end
+
 
 package :msi do
   upgrade_code "29B5AA66-46B3-4676-8D67-2F3FB31CC549"

--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -43,20 +43,15 @@ package :deb do
   vendor vendor
 end
 
-def sign_rpm?
-  Gem::Version.new(ohai["platform_version"]) >= Gem::Version.new(6)
-end
-
-def gpg_passphrase_set?
-  ! (ENV["GPG_PASSPHRASE"].nil? || ENV["GPG_PASSPHRASE"].empty?)
-end
-
 package :rpm do
   category "Monitoring"
   vendor vendor
-  if sign_rpm?
-    raise "GPG Passphrase not provided" unless gpg_passphrase_set?
-    signing_passphrase ENV["GPG_PASSPHRASE"]
+  if Gem::Version.new(ohai["platform_version"]) >= Gem::Version.new(6)
+    if (ENV["GPG_PASSPHRASE"].nil? || ENV["GPG_PASSPHRASE"].empty?)
+      raise "GPG Passphrase not provided"
+    else
+      signing_passphrase ENV["GPG_PASSPHRASE"]
+    end
   end
 end
 

--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -61,6 +61,13 @@ when "rhel"
     package "gpg"
     package "pygpgme"
 
+    file ::File.join(build_user_home, '.gpg_passphrase') do
+      owner 'root'
+      mode 0600
+      content node["omnibus_sensu"]["gpg_passphrase"]
+      sensitive true
+    end
+
     gnupg_tar_path = ::File.join(build_user_home, 'gnupg.tar')
 
     aws_s3_file gnupg_tar_path do
@@ -121,7 +128,6 @@ end
 shared_env = {
   "SENSU_VERSION" => node["omnibus_sensu"]["build_version"],
   "BUILD_NUMBER" => node["omnibus_sensu"]["build_iteration"],
-  "GPG_PASSPHRASE" => node["omnibus_sensu"]["gpg_passphrase"]
 }
 
 omnibus_build "sensu" do

--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -62,7 +62,7 @@ when "rhel"
     package "pygpgme"
 
     file ::File.join(build_user_home, '.gpg_passphrase') do
-      owner 'root'
+      owner node["omnibus"]["build_user"]
       mode 0600
       content node["omnibus_sensu"]["gpg_passphrase"]
       sensitive true


### PR DESCRIPTION
* Avoid using custom methods and helpers that are out of scope when conditionally setting value for `signing_passphrase`
* Write GPG passphrase to file instead of injecting into ENV as this will inevitably be leaked into CI logs when compilation fails.