### PR TITLE
Place sensu-install in /usr/local/bin on macOS

### DIFF
--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -39,6 +39,9 @@ build do
   if freebsd?
     etc_dir = "/usr/local/etc"
     usr_bin_dir = "/usr/local/bin"
+  elsif mac_os_x?
+    etc_dir = "/etc"
+    usr_bin_dir = "/usr/local/bin"
   else
     etc_dir = "/etc"
     usr_bin_dir = "/usr/bin"


### PR DESCRIPTION
In the more recent versions of macOS, certain system directories are protected from being written to (including `/usr/bin`). It appears that it is recommended to use `/usr/local/bin` as an alternative.