### PR TITLE
Update sensu-plugin version to 1.4.5

### DIFF
--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -29,7 +29,7 @@ build do
       " --no-ri --no-rdoc", env: env
 
   gem "install sensu-plugin" \
-      " --version '1.4.4'" \
+      " --version '1.4.5'" \
       " --no-ri --no-rdoc", env: env
 
   share_dir = File.join(install_dir, "embedded", "share", "sensu")


### PR DESCRIPTION
Adds support for globally disabling the library's deprecated filter methods.