### PR TITLE
LSB compatibility fix

### DIFF
--- a/config/templates/sensu-gem/sysvinit/sensu-service.erb
+++ b/config/templates/sensu-gem/sysvinit/sensu-service.erb
@@ -272,7 +272,7 @@ stop() {
         return $retval
     else
       log_action_msg "$service_name is stopped"
-      return 3
+      return 0
     fi
 }
 


### PR DESCRIPTION
The sysvinit script should exit with a status code of 0 when trying to stop and already stopped service.

Fixes #120 