### PR TITLE
Remove HTML from Mac license

### DIFF
--- a/resources/sensu/pkg/license.html.erb
+++ b/resources/sensu/pkg/license.html.erb
@@ -1,22 +1,20 @@
-<div style="text-align: center">
-Copyright (c) 2017 Sonian Inc.<br />
-<br />
-Permission is hereby granted, free of charge, to any person obtaining<br />
-a copy of this software and associated documentation files (the<br />
-"Software"), to deal in the Software without restriction, including<br />
-without limitation the rights to use, copy, modify, merge, publish,<br />
-distribute, sublicense, and/or sell copies of the Software, and to<br />
-permit persons to whom the Software is furnished to do so, subject to<br />
-the following conditions:<br />
-<br />
-The above copyright notice and this permission notice shall be<br />
-included in all copies or substantial portions of the Software.<br />
-<br />
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,<br />
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF<br />
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND<br />
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE<br />
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION<br />
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION<br />
+Copyright (c) 2017 Sonian Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-</div>


### PR DESCRIPTION
Unfortunately, the HTML-formatted license did not get rendered as I had expected it to. This PR removes all of the HTML from the MIT license we include with our Mac packages.