### PR TITLE
Systemd service files should not be executable

### DIFF
--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -148,7 +148,7 @@ build do
         :service_name => sensu_service,
         :service_shortname => sensu_service.gsub(/sensu[-_]/, "")
       },
-      mode: 0755
+      mode: Helpers::permissions_for_service_manager(service_manager)
     }
     erb(options)
     project.extra_package_file(destination)

--- a/helpers.rb
+++ b/helpers.rb
@@ -111,4 +111,13 @@ module Helpers
       raise "Could not determine filename for #{service} and #{service_manager}"
     end
   end
+
+  def self.permissions_for_service_manager(service_manager)
+    case service_manager
+    when :systemd
+      0644
+    else
+      0755
+    end
+  end
 end


### PR DESCRIPTION
As noted by #163, the systemd service files that are installed by the Linux packages should not have the execute bit set on them. This PR should fix #163.