### PR TITLE
Update winsw to 2.0.2

### DIFF
--- a/config/software/winsw.rb
+++ b/config/software/winsw.rb
@@ -1,7 +1,11 @@
 name "winsw"
-default_version "2.0.1"
+default_version "2.0.2"
 
 source url: "https://github.com/kohsuke/winsw/releases/download/winsw-v#{version}/WinSW.NET4.exe"
+
+version "2.0.2" do
+  source md5: "636111424c86c47c2ebae8766a377d82"
+end
 
 version "2.0.1" do
   source md5: "6f9f9554e66cdf3bb26d80512b7afc4f"


### PR DESCRIPTION
This update includes a fix to improve termination of child processes.
See https://github.com/kohsuke/winsw/issues/95 and https://github.com/kohsuke/winsw/pull/186