### PR TITLE
Update to latest OpenSSL recipe from omnibus-software

### DIFF
--- a/config/patches/openssl/openssl-1.0.2k-no-bang.patch
+++ b/config/patches/openssl/openssl-1.0.2k-no-bang.patch
@@ -1,0 +1,17 @@
+--- a/util/domd
++++ b/util/domd
+@@ -34,11 +34,11 @@ else
+     ${PERL} $TOP/util/clean-depend.pl < Makefile > Makefile.new
+     RC=$?
+ fi
+-if ! cmp -s Makefile.save Makefile.new; then
+-    mv Makefile.new Makefile
+-else
++if cmp -s Makefile.save Makefile.new; then
+     mv Makefile.save Makefile
+     rm -f Makefile.new
++else
++    mv Makefile.new Makefile
+ fi
+ # unfake the presence of Kerberos
+ rm $TOP/krb5.h


### PR DESCRIPTION
This PR updates our OpenSSL recipe to the latest from the omnibus-software repository (with our Windows changes re-applied). The no-bang patch is necessary for our builds to succeed on Solaris 10.