### PR TITLE
Use correct SHA256 checksum for Ruby 2.4.1 .tar.gz

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -41,7 +41,7 @@ dependency "libyaml"
 # and that's the only one we will ever use.
 dependency "libiconv"
 
-version("2.4.1")      { source sha256: "ccfb2d0a61e2a9c374d51e099b0d833b09241ee78fc17e1fe38e3b282160237c" }
+version("2.4.1")      { source sha256: "a330e10d5cb5e53b3a0078326c5731888bb55e32c4abfeb27d9e7f8e5d000250" }
 version("2.4.0")      { source sha256: "152fd0bd15a90b4a18213448f485d4b53e9f7662e1508190aa5b702446b29e3d" }
 
 version("2.3.1")      { source sha256: "b87c738cb2032bf4920fef8e3864dc5cf8eae9d89d8d523ce0236945c5797dcd" }


### PR DESCRIPTION
I mistakingly added the SHA256 checksum for the .tar.bz2 package of Ruby 2.4.1. This PR corrects the mistake.