### PR TITLE
Solaris 10/11 CFLAGS/CPPFLAGS fixes & relocation

### DIFF
--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -109,11 +109,14 @@ elsif aix?
 elsif solaris_10?
   if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9"
+    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9 -fms-extensions"
     env["LDFLAGS"] << " -mcpu=v9"
   else
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe"
+    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -fms-extensions"
   end
+elsif solaris_11?
+  env["CFLAGS"] << " -std=c99"
+  env["CPPFLAGS"] << " -D_XOPEN_SOURCE=600 -D_XPG6"
 elsif windows?
   env["CPPFLAGS"] << " -DFD_SETSIZE=2048"
 else # including linux

--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -19,17 +19,10 @@ build do
 
   files_dir = "#{project.files_path}/#{name}"
 
-  gem_install_extras = ""
-
-  if solaris_10?
-    gem_install_extras << " --with-cflags=\"-fms-extensions\""
-  end
-
   gem "install sensu" \
       " --version '#{version}'" \
       " --bindir '#{install_dir}/embedded/bin'" \
-      " --no-ri --no-rdoc" \
-      " -- #{gem_install_extras}", env: env
+      " --no-ri --no-rdoc", env: env
 
   gem "install sensu-plugin" \
       " --version '1.4.5'" \


### PR DESCRIPTION
This PR moves the CFLAGS needed for the Sensu gem to install on Solaris 10 to Ruby where it will be used when installing any ruby gem.

It also adds some new CFLAGS and CPPFLAGS to the ruby definition that are necessary to make builds succeed on Solaris 11.