### PR TITLE
Omnibus build timeout

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -139,6 +139,7 @@ platforms:
     run_list: apt::default
   - name: windows-2012-r2
     driver:
+      image_id: ami-6f64f00f
       instance_type: m3.xlarge
     transport:
       name: winrm
@@ -146,7 +147,7 @@ platforms:
     run_list: seven_zip::default
   - name: windows-2012-r2-i386
     driver:
-      image_id: ami-1562d075
+      image_id: ami-6f64f00f
       instance_type: m3.xlarge
     transport:
       name: winrm

--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -136,6 +136,7 @@ omnibus_build "sensu" do
   build_user "root" unless windows?
   environment shared_env
   live_stream true
+  timeout 7200
 end
 
 pkg_suffix_map = {


### PR DESCRIPTION
Trying to address persistent build failures on Windows related to Taking Too Darn Long

* Update windows kitchen config to use AMI generated from [sensu-omnibus-packer](https://github.com/sensu/sensu-omnibus-packer/pull/2)
* Configure timeout on omnibus_build resource, depends on https://github.com/sensu/omnibus-cookbook/pull/2 (not yet contributed back upstream)