### PR TITLE
[winsw] fix source filename in copy directive

### DIFF
--- a/config/software/winsw.rb
+++ b/config/software/winsw.rb
@@ -23,7 +23,7 @@ build do
     # command_options = "/target:Clean;Build /p:Configuration=Release /p:PostBuildEvent="
     # command("MSBuild.exe src/winsw.sln #{command_options}", env: env)
     # copy("bin/Release/winsw.exe", "#{bin_dir}/winsw.exe")
-    copy("WinSW.NET4.exe", "#{bin_dir}/winsw.exe")
+    copy("WinSW.NET2.exe", "#{bin_dir}/winsw.exe")
   end
 end
 


### PR DESCRIPTION
In testing 0.29.0-2 MSI packages are missing sensu-client.exe. I believe this is because the source file name was not updated in the winsw software component configuration. This change should help 🌮 