### PR TITLE
[chef] ensure bundle is installed before populating cache

### DIFF
--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -141,6 +141,7 @@ execute "populate_omnibus_cache_s3" do
   command(
     <<-CODE.gsub(/^ {10}/, '')
           #{load_toolchain_cmd} && \
+          bundle install && \
           bundle exec omnibus cache missing && \
           bundle exec omnibus cache populate && \
           bundle exec omnibus cache missing


### PR DESCRIPTION
Per https://travis-ci.org/sensu/sensu-omnibus/jobs/218204007 and others:
```
bundler: command not found: omnibus
Install missing gem executables with `bundle install`
```