### PR TITLE
[chef] run cache population as root user

### DIFF
--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -148,7 +148,7 @@ execute "populate_omnibus_cache_s3" do
        CODE
     )
   cwd node["omnibus_sensu"]["project_dir"]
-  user node["omnibus"]["build_user"] unless windows?
+  user "root" unless windows?
   environment shared_env
   not_if { node["omnibus_sensu"]["publishers"]["s3"].any? {|k,v| v.nil? } }
 end


### PR DESCRIPTION
When running as `omnibus` user, the build fails on Debian and Centos:

```
There was an error while trying to write to `/root/.bundle/cache/git`. It is
likely that you need to grant write permissions for that path.
```