### PR TITLE
constrain dependencies to those strictly needed

### DIFF
--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -59,7 +59,8 @@ platform_version = ohai["platform_version"]
 
 case ohai['platform_family']
 when 'rhel'
-  runtime_dependency 'redhat-lsb'
+  runtime_dependency 'redhat-lsb-core'
+  runtime_dependency 'initscripts'
 end
 
 package :rpm do


### PR DESCRIPTION
Functionally identical but doesn't include Qt (among other needless things in the giant redhat-lsb package)