### PR TITLE
Add logrotate & defaults files as config files on linux

### DIFF
--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -83,13 +83,6 @@ package :pkg do
 end
 compress :dmg
 
-# TODO: config files are removed during actions such as dpkg --purge
-#if linux?
-#  config_file "/etc/sensu/conf.d/README.md"
-#  config_file "/etc/logrotate.d/sensu"
-#  config_file "/etc/default/sensu"
-#end
-
 # Make sure Windows gets a gem.bat
 dependency "shebang-cleanup" if windows?
 

--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -120,9 +120,14 @@ build do
   copy("#{files_dir}/default/sensu", "#{etc_dir}/default/sensu")
   copy("#{files_dir}/logrotate.d/sensu", "#{etc_dir}/logrotate.d/sensu")
 
-  # add extra package files (files outside of /opt/sensu)
-  project.extra_package_file("#{etc_dir}/default/sensu")
-  project.extra_package_file("#{etc_dir}/logrotate.d/sensu")
+  # add config & extra package files (files outside of /opt/sensu)
+  if linux?
+    project.config_file("#{etc_dir}/default/sensu")
+    project.config_file("#{etc_dir}/logrotate.d/sensu")
+  else
+    project.extra_package_file("#{etc_dir}/default/sensu")
+    project.extra_package_file("#{etc_dir}/logrotate.d/sensu")
+  end
   project.extra_package_file("#{usr_bin_dir}/sensu-install")
 
   # sensu-service


### PR DESCRIPTION
Should fix #166 for Linux packages only. The packagers on other platforms will likely need some work to specify Omnibus-specified "config_files" as configuration files. This needs to be tested.