### PR TITLE
Update sensu-plugin 2.0.0 to 2.0.1

### DIFF
--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -44,7 +44,7 @@ build do
       " --no-ri --no-rdoc", env: env
 
   gem "install sensu-plugin" \
-      " --version '2.0.0'" \
+      " --version '2.0.1'" \
       " --no-ri --no-rdoc", env: env
 
   share_dir = File.join(install_dir, "embedded", "share", "sensu")


### PR DESCRIPTION
sensu-plugin 2.0.1 loosens dependency on json gem from < 2.0.0 to < 3.0.0. See https://github.com/sensu-plugins/sensu-plugin/pull/173