### PR TITLE
Remove all redhat-lsb / initscript deps

### DIFF
--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -57,12 +57,6 @@ gpg_passphrase = begin
 
 platform_version = ohai["platform_version"]
 
-case ohai['platform_family']
-when 'rhel'
-  runtime_dependency 'redhat-lsb-core'
-  runtime_dependency 'initscripts'
-end
-
 package :rpm do
   category "Monitoring"
   vendor vendor


### PR DESCRIPTION
Just requires a documentation change elsewhere, as these are not, strictly speaking, 'sensu' dependencies.