### PR TITLE
Unblock build failures on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ files/**/cache/
 vendor/cookbooks
 *~
 .envrc
+site-cookbooks/omnibus_sensu/files/default/archive.zip

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -161,7 +161,7 @@ suites:
     - omnibus_sensu::default
     attributes:
       omnibus_sensu:
-        project_revision: "<%= ENV['PROJECT_REVISION'] || `git rev-parse HEAD` %>"
+        project_revision: "<%= ENV['PROJECT_REVISION'] || `git describe --all`.chomp %>"
         build_version: "<%= build_version %>"
         build_iteration: "<%= build_iteration %>"
         gpg_passphrase: "<%= ENV['GPG_PASSPHRASE'] %>"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -161,7 +161,8 @@ suites:
     - omnibus_sensu::default
     attributes:
       omnibus_sensu:
+        project_revision: "<%= ENV['PROJECT_REVISION'] || 'master' %>"
         build_version: "<%= build_version %>"
         build_iteration: "<%= build_iteration %>"
-        gpg_passphrase: "<%= ENV["GPG_PASSPHRASE"] %>"
-        windows_target_version: "<%= ENV["WINDOWS_TARGET_VERSION"] %>"
+        gpg_passphrase: "<%= ENV['GPG_PASSPHRASE'] %>"
+        windows_target_version: "<%= ENV['WINDOWS_TARGET_VERSION'] %>"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -161,7 +161,7 @@ suites:
     - omnibus_sensu::default
     attributes:
       omnibus_sensu:
-        project_revision: "<%= ENV['PROJECT_REVISION'] || 'master' %>"
+        project_revision: "<%= ENV['PROJECT_REVISION'] || `git describe --all` %>"
         build_version: "<%= build_version %>"
         build_iteration: "<%= build_iteration %>"
         gpg_passphrase: "<%= ENV['GPG_PASSPHRASE'] %>"

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -161,7 +161,7 @@ suites:
     - omnibus_sensu::default
     attributes:
       omnibus_sensu:
-        project_revision: "<%= ENV['PROJECT_REVISION'] || `git describe --all` %>"
+        project_revision: "<%= ENV['PROJECT_REVISION'] || `git rev-parse HEAD` %>"
         build_version: "<%= build_version %>"
         build_iteration: "<%= build_iteration %>"
         gpg_passphrase: "<%= ENV['GPG_PASSPHRASE'] %>"

--- a/Berksfile
+++ b/Berksfile
@@ -6,7 +6,7 @@ cookbook 'omnibus', git: 'https://github.com/sensu/omnibus-cookbook.git', ref: '
 
 # Explicitly pull in seven_zip for windows. For some reason this is
 # suddenly not being installed by build-essential cookbook
-cookbook 'seven_zip', '~> 2.0'
+cookbook 'seven_zip', git: 'https://github.com/windowschefcookbooks/seven_zip', ref: 'v2.0.2'
 
 # Uncomment to use the latest version of the Omnibus cookbook from GitHub
 # cookbook 'omnibus', github: 'opscode-cookbooks/omnibus'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'rubyzip'
 gem 'rake'
 
 # Install omnibus

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
+gem 'rubyzip'
 gem 'rake'
 
 # Install omnibus

--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,9 @@ begin
 rescue LoadError
   puts '>>>>> Kitchen gem not loaded, omitting tasks'
 end
+
+task 'archive' do
+  filedir = 'site-cookbooks/omnibus_sensu/files/default'
+  archive = File.join(filedir,'archive.zip')
+  `git archive --format=zip -o #{archive} HEAD`
+end

--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -77,9 +77,6 @@ package :pkg do
 end
 compress :dmg
 
-# Make sure Windows gets a gem.bat
-dependency "shebang-cleanup" if windows?
-
 # Creates required build directories
 dependency "preparation"
 
@@ -88,6 +85,9 @@ dependency "package-scripts" unless windows?
 
 # sensu dependencies/components
 dependency "sensu-gem"
+
+# Make sure Windows gets a gem.bat
+dependency "shebang-cleanup" if windows?
 
 # Version manifest file
 dependency "version-manifest"

--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -21,7 +21,7 @@
 
 name "shebang-cleanup"
 
-default_version "0.0.2"
+default_version "0.0.3"
 
 license :project_license
 skip_transitive_dependency_licensing true
@@ -61,7 +61,7 @@ build do
       end
 
       # Fix gem.bat
-      File.open("#{install_dir}/embedded/bin/gem.bat", "w") do |f|
+      File.open("#{install_dir}/embedded/bin/gem.bat", "w+") do |f|
         f.puts <<-EOF
 @ECHO OFF
 "%~dp0ruby.exe" "%~dpn0" %*

--- a/config/software/shebang-cleanup.rb
+++ b/config/software/shebang-cleanup.rb
@@ -29,69 +29,12 @@ skip_transitive_dependency_licensing true
 build do
   if windows?
     block "Update batch files to point at embedded ruby" do
-      load_gemspec = if Gem::VERSION >= "2"
-                       require "rubygems/package"
-                       Gem::Package.method(:new)
-                     else
-                       require "rubygems/format"
-                       Gem::Format.method(:from_file_by_path)
-                     end
-      Dir["#{install_dir.tr('\\', '/')}/embedded/lib/ruby/gems/**/cache/*.gem"].each do |gem_file|
-        load_gemspec.call(gem_file).spec.executables.each do |bin|
-          if File.exist?("#{install_dir}/bin/#{bin}")
-            File.open("#{install_dir}/bin/#{bin}.bat", "w") do |f|
-              f.puts <<-EOF
-@ECHO OFF
-"%~dp0..\\embedded\\bin\\ruby.exe" "%~dpn0" %*
-              EOF
-            end
-          end
-          if File.exist?("#{install_dir}/embedded/bin/#{bin}")
-            File.open("#{install_dir}/embedded/bin/#{bin}.bat", "w") do |f|
-              f.puts <<-EOF
-@ECHO OFF
-"%~dp0ruby.exe" "%~dpn0" %*
-              EOF
-            end
-          end
-          # Rubocop is silly and yells at you for structuring the
-          # last if statement the way it is.
-          next
-        end
-      end
-
       # Fix gem.bat
       File.open("#{install_dir}/embedded/bin/gem.bat", "w+") do |f|
         f.puts <<-EOF
 @ECHO OFF
 "%~dp0ruby.exe" "%~dpn0" %*
         EOF
-      end
-    end
-  else
-    block "Update shebangs to point to embedded Ruby" do
-      # Fix the shebang for binaries with shebangs that have:
-      # #!/usr/bin/env ruby
-      Dir.glob("#{install_dir}/embedded/bin/*") do |bin_file|
-        update_shebang = false
-        rest_of_the_file = ""
-
-        File.open(bin_file) do |f|
-          shebang = f.readline
-          if shebang.start_with?("#!") &&
-              shebang.include?("ruby") &&
-              !shebang.include?("#{install_dir}/embedded/bin/ruby")
-            rest_of_the_file = f.read
-            update_shebang = true
-          end
-        end
-
-        if update_shebang
-          File.open(bin_file, "w+") do |f|
-            f.puts("#!#{install_dir}/embedded/bin/ruby")
-            f.puts(rest_of_the_file)
-          end
-        end
       end
     end
   end

--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -104,12 +104,24 @@ end
 
 project_dir = windows? ? File.join("C:", node["omnibus_sensu"]["project_dir"]) : node["omnibus_sensu"]["project_dir"]
 
-git project_dir do
-  repository 'https://github.com/sensu/sensu-omnibus.git'
-  revision node["omnibus_sensu"]["project_revision"]
-  user node["omnibus"]["build_user"] unless windows?
-  group node["omnibus"]["build_user_group"] unless windows?
-  action :sync
+rev = node["omnibus_sensu"]["project_revision"]
+
+case rev
+when 'archive'
+  cookbook_file File.join(project_dir,'archive.zip') do
+    source 'archive.zip'
+    user node["omnibus"]["build_user"] unless windows?
+    group node["omnibus"]["build_user_group"] unless windows?
+    action :create
+  end
+else
+  git project_dir do
+    repository 'https://github.com/sensu/sensu-omnibus.git'
+    revision rev
+    user node["omnibus"]["build_user"] unless windows?
+    group node["omnibus"]["build_user_group"] unless windows?
+    action :sync
+  end
 end
 
 template ::File.join(node["omnibus_sensu"]["project_dir"], "omnibus.rb") do


### PR DESCRIPTION
- Simplifies testing of changes on Windows outside of Travis - run `rake archive` to generate an archive that can be picked up by the chef cookbook, meaning less commit/tag pollution and no having to go to Github anyway (this being purely optional).
- Properly orders dependencies in the project definition; fixes what looks like a bug in the shebang-cleanup definition.

I was able to build successfully locally with this; Travis is running now!