### PR TITLE
Package provided systemd files should not go to /etc

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -68,7 +68,7 @@ module Helpers
       "\"#{service_manager}\" on platform \"#{platform_family}\""
     case service_manager
     when :systemd
-      "/etc/systemd/system"
+      "/usr/lib/systemd/system"
     when :sysvinit
       case platform_family
       when "debian"


### PR DESCRIPTION
/etc/systemd should only be used for machine-specific overrides. (https://www.freedesktop.org/software/systemd/man/systemd.unit.html)