### PR TITLE
Prevent systemd services from starting before network is online

### DIFF
--- a/config/templates/sensu-gem/systemd/sensu-service.erb
+++ b/config/templates/sensu-gem/systemd/sensu-service.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=sensu <%= service_shortname %>
+After=network-online.target
 
 [Service]
 User=sensu
@@ -10,4 +11,4 @@ Restart=on-failure
 RestartSec=1min
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target


### PR DESCRIPTION
Per https://sensucommunity.slack.com/archives/C68LV5M9U/p1501783154845983 it seems we are not using systemd's facilities for ensuring our services start after the network is available. This change should address that oversight.