### PR TITLE
build.sh now passes git tag as value of PROJECT_REVISION

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -170,7 +170,7 @@ suites:
     - omnibus_sensu::default
     attributes:
       omnibus_sensu:
-        project_revision: "<%= ENV['PROJECT_REVISION'] || `git describe --all`.chomp %>"
+        project_revision: "<%= ENV['PROJECT_REVISION'] %>"
         build_version: "<%= build_version %>"
         build_iteration: "<%= build_iteration %>"
         gpg_passphrase: "<%= ENV['GPG_PASSPHRASE'] %>"

--- a/build.sh
+++ b/build.sh
@@ -18,8 +18,9 @@ if [ "$(git describe --tags --exact-match "$OMNIBUS_COMMIT")" ]; then
 
     SENSU_VERSION=$(echo "$TAG" | awk -F'-' '{print $1}' | sed 's/v//g')
     BUILD_NUMBER=$(echo "$TAG" | awk -F'-' '{print $2}')
+    PROJECT_REVISION=$TAG
 
-    export SENSU_VERSION BUILD_NUMBER
+    export SENSU_VERSION BUILD_NUMBER PROJECT_REVISION
 
     echo "======================== Building ${SENSU_VERSION}-${BUILD_NUMBER} on ${BUILD_PLATFORM}"
 


### PR DESCRIPTION
test-kitchen will use value of PPROJECT_REVISION env var to determine
which revision of this repository to check for building.