### PR TITLE
debian systemd services are stored in /lib/systemd, not /usr/lib/systemd

### DIFF
--- a/helpers.rb
+++ b/helpers.rb
@@ -65,10 +65,10 @@ module Helpers
 
   def self.directory_for_service(platform_family, service_manager)
     unknown_combo = "No service directory defined for service manager " +
-      "\"#{service_manager}\" on platform \"#{platform_family}\""
+                    "\"#{service_manager}\" on platform \"#{platform_family}\""
     case service_manager
     when :systemd
-      "/usr/lib/systemd/system"
+      "/lib/systemd/system"
     when :sysvinit
       case platform_family
       when "debian"


### PR DESCRIPTION
After merging https://github.com/sensu/sensu-omnibus/pull/220 we have realized that the path used for systemd services does not exist on debian platforms. This PR stores the service files in `/lib/systemd/system` instead which will work across both debian & centos platforms as centos symlinks `/lib` to `/usr/lib`.