### PR TITLE
Detect .NET version and install corresponding winsw variant

### DIFF
--- a/config/projects/sensu.rb
+++ b/config/projects/sensu.rb
@@ -67,6 +67,7 @@ end
 
 package :msi do
   upgrade_code "29B5AA66-46B3-4676-8D67-2F3FB31CC549"
+  wix_candle_extension "WixNetFxExtension"
   wix_light_extension "WixNetFxExtension"
 end
 

--- a/config/software/sensu-gem.rb
+++ b/config/software/sensu-gem.rb
@@ -12,12 +12,8 @@ end
 dependency "eventmachine"
 
 if windows?
-  case ENV["WINDOWS_TARGET_VERSION"]
-  when "2003","2008","2008r2"
-    dependency "winsw-net2"
-  else
-    dependency "winsw-net4"
-  end
+  dependency "winsw-net2"
+  dependency "winsw-net4"
 end
 
 build do
@@ -179,7 +175,6 @@ build do
   if windows?
     copy("#{files_dir}/sensu-client-windows.xml", "#{bin_dir}/sensu-client.xml")
     copy("#{files_dir}/sensu-client.exe.config", "#{bin_dir}/sensu-client.exe.config")
-    move("#{bin_dir}/winsw.exe", "#{bin_dir}/sensu-client.exe")
   else
     link("#{embedded_bin_dir}/sensu-client", "#{bin_dir}/sensu-client")
     link("#{embedded_bin_dir}/sensu-server", "#{bin_dir}/sensu-server")

--- a/config/software/winsw-net2.rb
+++ b/config/software/winsw-net2.rb
@@ -18,6 +18,6 @@ build do
   bin_dir = File.join(install_dir, "bin")
 
   if windows?
-    copy("WinSW.NET2.exe", "#{bin_dir}/winsw.exe")
+    copy("WinSW.NET2.exe", "#{bin_dir}/WinSW.NET2.exe")
   end
 end

--- a/config/software/winsw-net4.rb
+++ b/config/software/winsw-net4.rb
@@ -18,6 +18,6 @@ build do
   bin_dir = File.join(install_dir, "bin")
 
   if windows?
-    copy("WinSW.NET4.exe", "#{bin_dir}/winsw.exe")
+    copy("WinSW.NET4.exe", "#{bin_dir}/WinSW.NET4.exe")
   end
 end

--- a/resources/sensu/msi/source.wxs.erb
+++ b/resources/sensu/msi/source.wxs.erb
@@ -36,10 +36,6 @@
       <![CDATA[Installed OR VersionNT >= 601]]>
     </Condition -->
 
-    <Condition Message="This application requires .NET Framework 2.0 or newer. Please install the .NET Framework then run this installer again.">
-      <![CDATA[Installed OR NETFRAMEWORK20 OR WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED]]>
-    </Condition>
-
     <!-- Major upgrade -->
     <Upgrade Id="$(var.UpgradeCode)">
       <UpgradeVersion OnlyDetect="yes" Minimum="$(var.VersionNumber)" IncludeMinimum="no" Property="NEWERVERSIONDETECTED" />

--- a/resources/sensu/msi/source.wxs.erb
+++ b/resources/sensu/msi/source.wxs.erb
@@ -1,5 +1,9 @@
 <?xml version='1.0'?>
-<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:util="http://schemas.microsoft.com/wix/UtilExtension">
+<Wix
+    xmlns="http://schemas.microsoft.com/wix/2006/wi"
+    xmlns:util="http://schemas.microsoft.com/wix/UtilExtension"
+    xmlns:netfx="http://schemas.microsoft.com/wix/NetFxExtension"
+>
 
   <!-- This is how we include wxi files -->
   <?include "parameters.wxi" ?>
@@ -9,7 +13,7 @@
     Name is made of localized product name and version number.
   -->
   <Product Id="*" Name="!(loc.ProductName)" Language="!(loc.LANG)"
-          Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
+           Version="$(var.VersionNumber)" Manufacturer="!(loc.ManufacturerName)" UpgradeCode="$(var.UpgradeCode)">
 
     <!--
       Minimum installer version (2.0) - Window XP and above.
@@ -17,6 +21,10 @@
     -->
     <Package InstallerVersion="200" InstallPrivileges="elevated"
              Compressed="yes" InstallScope="perMachine" />
+
+    <!-- Include .NET Framework properties -->
+    <PropertyRef Id="NETFRAMEWORK20"/>
+    <PropertyRef Id="WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED"/>
 
     <Media Id="1" Cabinet="Project.cab" EmbedCab="yes" CompressionLevel="high" />
 
@@ -27,6 +35,10 @@
     <!-- Condition Message="!(loc.MinimumOSVersionMessage)">
       <![CDATA[Installed OR VersionNT >= 601]]>
     </Condition -->
+
+    <Condition Message="This application requires .NET Framework 2.0 or newer. Please install the .NET Framework then run this installer again.">
+      <![CDATA[Installed OR NETFRAMEWORK20 OR WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED]]>
+    </Condition>
 
     <!-- Major upgrade -->
     <Upgrade Id="$(var.UpgradeCode)">
@@ -77,6 +89,7 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WINDOWSVOLUME">
 <% hierarchy.each.with_index do |(name, id), index| -%>
+        <% puts "YOLO: added #{name} with id #{id}" %>
         <%= '  '*index %><Directory Id="<%= id %>" Name="<%= name %>">
 <% end -%>
 <% hierarchy.keys.each.with_index do |_, index| -%>
@@ -92,6 +105,24 @@
                      Part="last" System="yes"
                      Value="[PROJECTLOCATION]bin;[PROJECTLOCATION]embedded\bin" />
       </Component>
+      <Component Id="SensuServiceWrapperNET4"
+                 Guid="{60098D5D-BBA4-41C6-8F6F-DA600CC4834C}">
+        <Condition>
+          WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED
+        </Condition>
+        <CopyFile Id="CopySensuServiceWrapperNET4"
+                  FileId="fil2730CA0415D63723292B43F1184FB6DC"
+                  DestinationDirectory="dirAACB971AAE53CD846725B5E3EF1FFD5C" DestinationName="sensu-client.exe" />
+      </Component>
+      <Component Id="SensuServiceWrapperNET2"
+                 Guid="{60098D5D-BBA4-41C6-8F6F-DA600DD4834D}">
+        <Condition>
+          NETFRAMEWORK20 AND NOT WIX_IS_NETFRAMEWORK_40_OR_LATER_INSTALLED
+        </Condition>
+        <CopyFile Id="CopySensuServiceWrapperNET2"
+                  FileId="fil21EAF549C118E62490D5F1CA8D307009"
+                  DestinationDirectory="dirAACB971AAE53CD846725B5E3EF1FFD5C" DestinationName="sensu-client.exe" />
+      </Component>
     </DirectoryRef>
 
     <SetDirectory Id="WINDOWSVOLUME" Value="[WindowsVolume]" />
@@ -100,6 +131,8 @@
     <Feature Id="ProjectFeature" Title="!(loc.FeatureMainName)" Absent="disallow" AllowAdvertise="no" Level="1" ConfigurableDirectory="<%= wix_install_dir %>">
       <ComponentGroupRef Id="ProjectDir" />
       <ComponentRef Id="SensuPath" />
+      <ComponentRef Id="SensuServiceWrapperNET4" />
+      <ComponentRef Id="SensuServiceWrapperNET2" />
     </Feature>
 
     <!-- UI Stuff -->

--- a/resources/sensu/msi/source.wxs.erb
+++ b/resources/sensu/msi/source.wxs.erb
@@ -89,7 +89,6 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="WINDOWSVOLUME">
 <% hierarchy.each.with_index do |(name, id), index| -%>
-        <% puts "YOLO: added #{name} with id #{id}" %>
         <%= '  '*index %><Directory Id="<%= id %>" Name="<%= name %>">
 <% end -%>
 <% hierarchy.keys.each.with_index do |_, index| -%>


### PR DESCRIPTION
MSI now determines whether .NET Framework version ==2.0 or  >= 4.0 is available and copy the corresponding winsw executable in `\opt\sensu\bin` to `sensu-client.exe`.

~Installer now raises an error if no suitable .NET Framework is available.~ In keeping with prior installer behavior, no error is raised when .NET Framework is not available.

❤️  to @amdprophet for slogging through this with me!

Closes #234 