### PR TITLE
Adjust Solaris SMF to properly use sensu-service binstub

### DIFF
--- a/config/templates/sensu-gem/smf/sensu-service.erb
+++ b/config/templates/sensu-gem/smf/sensu-service.erb
@@ -15,7 +15,7 @@
             <service_fmri value="svc:/milestone/multi-user"/>
         </dependency>
         <exec_method timeout_seconds="60" type="method" name="start"
-            exec="/opt/sensu/bin/sensu-service <%= service_shortname %>"/>
+            exec="/opt/sensu/bin/sensu-service start <%= service_shortname %>"/>
         <!--
             The exec attribute below can be changed to a command that SMF
             should execute to stop the service.  See smf_method(5) for more

--- a/platform-docs/AIX.md
+++ b/platform-docs/AIX.md
@@ -105,11 +105,11 @@ than two hours.
   cd sensu-omnibus
   ```
   
-3. Check out the desired revision of sensu-omnibus, e.g. `release/1.1` branch:
+3. Check out the desired tag of sensu-omnibus, e.g. `v1.2.0-1` branch:
 
-   ```
-   git checkout release/1.1
-   ```
+  ```sh
+  git checkout v1.2.0-1
+  ```
 
 4. Install gem dependencies:
 


### PR DESCRIPTION
This was missed when we created the `sensu-service` binstub. I've tested this and it's now functional.