### PR TITLE
Use git bundled with omnibus-toolchain instead of system git

### DIFF
--- a/site-cookbooks/omnibus_sensu/recipes/default.rb
+++ b/site-cookbooks/omnibus_sensu/recipes/default.rb
@@ -143,6 +143,7 @@ else
   git project_dir do
     repository 'https://github.com/sensu/sensu-omnibus.git'
     revision rev
+    environment ({"PATH" => '/opt/omnibus-toolchain/bin:/opt/omnibus-toolchain/embedded/bin:/usr/local/bin:$PATH'}) unless windows?
     user node["omnibus"]["build_user"] unless windows?
     group node["omnibus"]["build_user_group"] unless windows?
     action :sync


### PR DESCRIPTION
This fixes an issue where centos-5, centos-5-i386, and centos-6-i386 were not able to git clone this repository.