### PR TITLE
fix cert.pem linking

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -47,7 +47,7 @@ build do
 
   # Windows does not support symlinks
   unless windows?
-    link "certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem", unchecked: true
+    link "#{install_dir}/embedded/ssl/certs/cacert.pem", "#{install_dir}/embedded/ssl/cert.pem", unchecked: true
 
     block { File.chmod(0644, "#{install_dir}/embedded/ssl/certs/cacert.pem") }
   end


### PR DESCRIPTION
failure in `cert.pem` linking results in completely broken OpenSSL cert management 