### PR TITLE
Fix for upgrading from sensu rpms older than 1.3.0 using systemd

### DIFF
--- a/config/templates/package-scripts/postrm.erb
+++ b/config/templates/package-scripts/postrm.erb
@@ -62,6 +62,23 @@ if [ $1 -eq 0 ]; then
   purge_sensu_services
   purge_sensu_files
 fi
+##
+# Note: 
+#   Old versions of the sensu package when uninstalled may remove
+#   systemd service files in older locations as part of rpm operaton.
+#   Make sure to daemon-reload to keep systemd happy
+# Ref: Impacts rpms build prior to Issue #240 commit
+##
+using_systemd()
+{
+    [ -e "/proc/1/comm" ] && grep -q "^systemd$" /proc/1/comm
+}
+set +e
+if using_systemd; then
+    systemctl daemon-reload
+fi
+set -e
+
 <% when "debian" -%>
 case "$1" in
   purge)


### PR DESCRIPTION
Okay I think this will fix the issue with upgrading from sensu 1.1.x rpms on Centos.
#264 

I'm pretty sure you just need a systemctl daemon-reload in the postun script that always fires.

When updating rpm first installs the new package and runs the pre/post install scriptlet. Then does the uninstall of the old package and runs the pre/post uninstall scriptlet.

For old packages the package uninstall of the old package removes service files from /etc/ after the call to daemon-reload in postint. 


I don't have the debian packaging chops to know what the correct fix is for deb systems.  

I could use some pointers on how to smoke test this locally and produce rpms with the new scriptlet. 
If omnibus was producing an srpm as a artifact, I could more easily smoke test potential changes.

-jef