### PR TITLE
Pin CentOS 7 AMI

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -63,6 +63,8 @@ provisioner:
 
 platforms:
   - name: centos-7
+    driver:
+      image_id: ami-a042f4d8
     run_list: yum-epel::default
   - name: centos-7-i386
     run_list: yum-epel::default


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

CentOS 7.5 updates the binutils package to version 2.27 which adds support for the `--compress-debug-sections=zlib` LDFLAG. When Ruby is built on CentOS 7.5 it is adding the LDFLAG to rbconfig which breaks the installation of some Sensu plugins on CentOS 7.4 or earlier.