### PR TITLE
Fix systemd unit

### DIFF
--- a/config/templates/sensu-gem/systemd/sensu-service.erb
+++ b/config/templates/sensu-gem/systemd/sensu-service.erb
@@ -1,6 +1,7 @@
 [Unit]
 Description=sensu <%= service_shortname %>
 After=network-online.target
+Wants=network-online.target
 
 [Service]
 User=sensu
@@ -11,4 +12,4 @@ Restart=on-failure
 RestartSec=1min
 
 [Install]
-WantedBy=network-online.target
+WantedBy=multi-user.target


### PR DESCRIPTION
I think there have been some confusion in this pr: https://github.com/sensu/sensu-omnibus/pull/229

I first noticed some strange issues on our servers, where the sensu-client was sometimes loaded, sometime not, without any reasonable explanations.
I then realized that when it was not loaded, the `network-online.target` systemd unit was not reached too.

So the bug appeared on servers where sensu-client was the *only* service needing `network-online.target`.

The systemd documentation is pretty clear: https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/#cutthecraphowdoimakesurethatmyservicestartsafterthenetworkisreallyonline

So we *must* use `Wants=network-online.target` (which is obvious when you realize that network-online must be pulled in), and to avoid chicken/eggs issues, rollback `WantedBy` to something else, like `multi-user.target` which mimics runlevels 2 3 4 5, just like the good olds sysvinit scripts.