### PR TITLE
[aarch64] Add updated config.guess to libltdl

### DIFF
--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -39,6 +39,7 @@ build do
     # Update config.guess to support newer platforms (like aarch64)
     if version == "2.4"
       update_config_guess
+      update_config_guess(target: "libltdl/config")
     end
   end
 


### PR DESCRIPTION
Inside libtool, libltdl also tries to run config.guess which fails
on platforms like aarch64.  This patch adds it to the list of folders
which are updated with newer config.guess to get aarch64 support.

We can also provide CI resources for Sensu if you'd like to run aarch64
builds on our OpenStack cloud

Signed-off-by: Mohammed Naser <mnaser@vexxhost.com>