### PR TITLE
Improve compatibility for sensu-install on non-bash platforms

### DIFF
--- a/files/sensu-gem/bin/sensu-install
+++ b/files/sensu-gem/bin/sensu-install
@@ -47,8 +47,10 @@ if [ -f $ETC_DIR/default/sensu-install ]; then
 fi
 
 if [ $EMBEDDED_RUBY = "true" ]; then
-    export PATH=/opt/sensu/embedded/bin:$PATH
-    export GEM_PATH=/opt/sensu/embedded/lib/ruby/gems/2.4.0:$GEM_PATH
+    PATH=/opt/sensu/embedded/bin:$PATH
+    GEM_PATH=/opt/sensu/embedded/lib/ruby/gems/2.4.0:$GEM_PATH
+    export PATH
+    export GEM_PATH
 fi
 
 /opt/sensu/embedded/bin/sensu-install $@


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

This change is needed to allow sensu-install to run in the default shell in Solaris (and likely AIX too).