### PR TITLE
Solaris 10 sparc fixes

### DIFF
--- a/config/patches/libffi/libffi-3.2.1-makefiles-sparc.patch
+++ b/config/patches/libffi/libffi-3.2.1-makefiles-sparc.patch
@@ -1,0 +1,24 @@
+diff -U 2 libffi-3.2.1-orig/Makefile.am libffi-3.2.1/Makefile.am
+--- libffi-3.2.1-orig/Makefile.am	2018-10-09 12:59:24.000000000 -0700
++++ libffi-3.2.1/Makefile.am	2018-10-09 13:00:02.000000000 -0700
+@@ -72,8 +72,4 @@
+ 	'CFLAGS_FOR_BUILD=$(CFLAGS_FOR_BUILD)' \
+ 	'CFLAGS_FOR_TARGET=$(CFLAGS_FOR_TARGET)' \
+-	'INSTALL=$(INSTALL)' \
+-	'INSTALL_DATA=$(INSTALL_DATA)' \
+-	'INSTALL_PROGRAM=$(INSTALL_PROGRAM)' \
+-	'INSTALL_SCRIPT=$(INSTALL_SCRIPT)' \
+ 	'JC1FLAGS=$(JC1FLAGS)' \
+ 	'LDFLAGS=$(LDFLAGS)' \
+diff -U 2 libffi-3.2.1-orig/Makefile.in libffi-3.2.1/Makefile.in
+--- libffi-3.2.1-orig/Makefile.in	2018-10-09 12:59:29.000000000 -0700
++++ libffi-3.2.1/Makefile.in	2018-10-09 12:59:58.000000000 -0700
+@@ -667,8 +667,4 @@
+ 	'CFLAGS_FOR_BUILD=$(CFLAGS_FOR_BUILD)' \
+ 	'CFLAGS_FOR_TARGET=$(CFLAGS_FOR_TARGET)' \
+-	'INSTALL=$(INSTALL)' \
+-	'INSTALL_DATA=$(INSTALL_DATA)' \
+-	'INSTALL_PROGRAM=$(INSTALL_PROGRAM)' \
+-	'INSTALL_SCRIPT=$(INSTALL_SCRIPT)' \
+ 	'JC1FLAGS=$(JC1FLAGS)' \
+ 	'LDFLAGS=$(LDFLAGS)' \

--- a/config/patches/ruby/ruby-no-m32-cflag.patch
+++ b/config/patches/ruby/ruby-no-m32-cflag.patch
@@ -1,0 +1,38 @@
+Only in ruby-2.4.4-orig: .document
+Only in ruby-2.4.4-orig: .editorconfig
+Only in ruby-2.4.4-orig: .ext
+Only in ruby-2.4.4-orig: .gdbinit
+Only in ruby-2.4.4-orig: .gitattributes
+Only in ruby-2.4.4-orig: .gitignore
+Only in ruby-2.4.4-orig: .indent.pro
+Only in ruby-2.4.4-orig: .revision.time
+Only in ruby-2.4.4-orig: .travis.yml
+diff -U 2 ruby-2.4.4-orig/configure ruby-2.4.4/configure
+--- ruby-2.4.4-orig/configure	2018-10-10 13:32:53.000000000 -0700
++++ ruby-2.4.4/configure	2018-10-10 13:41:11.000000000 -0700
+@@ -5641,8 +5641,8 @@
+ # RUBY_UNIVERSAL_ARCH begin
+ ARCH_FLAG=`expr " $CXXFLAGS " : '.* \(-m[0-9][0-9]*\) '`
+-test ${CXXFLAGS+set} && CXXFLAGS=`echo "$CXXFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
++#test ${CXXFLAGS+set} && CXXFLAGS=`echo "$CXXFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
+ ARCH_FLAG=`expr " $CFLAGS " : '.* \(-m[0-9][0-9]*\) '`
+-test ${CFLAGS+set} && CFLAGS=`echo "$CFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
+-test ${LDFLAGS+set} && LDFLAGS=`echo "$LDFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
++#test ${CFLAGS+set} && CFLAGS=`echo "$CFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
++#test ${LDFLAGS+set} && LDFLAGS=`echo "$LDFLAGS" | sed -e 's/ *-arch  *[^ ]*//g' -e 's/ *-m32//g' -e 's/ *-m64//g'`
+ unset universal_binary universal_archnames
+ if test ${target_archs+set}; then
+@@ -5701,5 +5701,5 @@
+     ARCH_FLAG=-m64 ;; #(
+   i[3-6]86) :
+-    ARCH_FLAG=-m32 ;; #(
++    ;; #(
+   *) :
+     as_fn_error $? "unknown target architecture: $target_archs" "$LINENO" 5
+@@ -5777,5 +5777,5 @@
+     ARCH_FLAG=-m64 ;; #(
+   i[3-6]86) :
+-    ARCH_FLAG=-m32 ;; #(
++    ;; #(
+   *) :
+     as_fn_error $? "unknown target architecture: $target_archs" "$LINENO" 5

--- a/config/patches/ruby/ruby-remove-headc.patch
+++ b/config/patches/ruby/ruby-remove-headc.patch
@@ -1,0 +1,10 @@
+diff -U 2 ruby-2.4.4-orig/configure ruby-2.4.4/configure
+--- ruby-2.4.4-orig/configure	2018-10-09 14:42:10.000000000 -0700
++++ ruby-2.4.4/configure	2018-10-09 14:40:33.000000000 -0700
+@@ -425,5 +425,5 @@
+ else
+ 
+-	$as_echo_n "   * $1:                     " | head -c26
++	$as_echo_n "   * $1:                     " | dd bs=1 count=26 2>/dev/null
+ 	if test "$FOLD"; then :
+ 

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -52,6 +52,10 @@ build do
   configure(*configure_command, env: env)
 
   if solaris_10?
+    if version == "3.2.1" && sparc?
+      patch source: "libffi-3.2.1-makefiles-sparc.patch", plevel: 1, env: env
+    end
+
     # run old make :(
     make env: env, bin: "/usr/ccs/bin/make"
     make "install", env: env, bin: "/usr/ccs/bin/make"

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -110,7 +110,7 @@ elsif aix?
 elsif solaris_10?
   if sparc?
     # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
-    env["CFLAGS"] << " -std=c99 -O3 -g -pipe -mcpu=v9 -fms-extensions"
+    env["CFLAGS"] << " -std=c99 -g -pipe -mcpu=v9 -fms-extensions"
     env["LDFLAGS"] << " -mcpu=v9"
   else
     env["CFLAGS"] << " -std=c99 -O3 -g -pipe -fms-extensions"
@@ -136,6 +136,10 @@ build do
 
   if solaris_10? && version.satisfies?(">= 2.1")
     patch source: "ruby-no-stack-protector.patch", plevel: 1, env: patch_env
+    if version.satisfies?("= 2.4.4") && sparc?
+      patch source: "ruby-remove-headc.patch", plevel: 1, env: patch_env
+      patch source: "ruby-no-m32-cflag.patch", plevel: 1, env: patch_env
+    end
   elsif solaris_11? && version =~ /^2.1/
     patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1, env: patch_env
   end


### PR DESCRIPTION
Signed-off-by: Justin Kolberg <amd.prophet@gmail.com>

A few things of note:

* `head -c` is not a valid flag on Solaris 10; use `dd count=` instead
* Had to remove the `-m32` flag that the ruby configure script adds
* The `-O3` CFLAG makes ruby builds unhappy with the error `There are only 32 single precision f registers`